### PR TITLE
fix(hubble): audit binary dist packaging

### DIFF
--- a/hugegraph-hubble/Dockerfile
+++ b/hugegraph-hubble/Dockerfile
@@ -41,4 +41,4 @@ COPY --from=build /pkg/hugegraph-hubble/apache-hugegraph-hubble-*/ /hubble
 WORKDIR /hubble/
 
 EXPOSE 8088
-ENTRYPOINT ["./bin/start-hubble.sh", "-f true"]
+ENTRYPOINT ["./bin/start-hubble.sh", "-f"]

--- a/hugegraph-hubble/hubble-dist/assembly/descriptor/assembly.xml
+++ b/hugegraph-hubble/hubble-dist/assembly/descriptor/assembly.xml
@@ -39,8 +39,15 @@
             <outputDirectory>/</outputDirectory>
             <includes>
                 <include>README*</include>
-                <include>LICENSE*</include>
-                <include>NOTICE*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>${release.docs.dir}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>LICENSE</include>
+                <include>NOTICE</include>
+                <include>licenses/**</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/hugegraph-hubble/hubble-dist/assembly/static/bin/start-hubble.sh
+++ b/hugegraph-hubble/hubble-dist/assembly/static/bin/start-hubble.sh
@@ -46,12 +46,32 @@ JAVA_OPTS="-Xms512m -Dfile.encoding=UTF-8"
 JAVA_DEBUG_OPTS=""
 FOREGROUND="false"
 
-while getopts "fd" arg; do
-    case ${arg} in
-        f) FOREGROUND="true" ;;
-        d) JAVA_DEBUG_OPTS=" -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n" ;;
-        ?) echo "USAGE: $0 [-f] [-d] " && exit 1 ;;
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -f|--foreground)
+            FOREGROUND="true"
+            if [[ $# -gt 1 && ( "$2" == "true" || "$2" == "false" ) ]]; then
+                FOREGROUND="$2"
+                shift
+            fi
+            ;;
+        "-f true"|"--foreground true")
+            FOREGROUND="true"
+            ;;
+        "-f false"|"--foreground false")
+            FOREGROUND="false"
+            ;;
+        -d|--debug)
+            JAVA_DEBUG_OPTS=" -Xdebug -Xnoagent"
+            JAVA_DEBUG_OPTS="${JAVA_DEBUG_OPTS} -Xrunjdwp:transport=dt_socket,address=8787"
+            JAVA_DEBUG_OPTS="${JAVA_DEBUG_OPTS},server=y,suspend=n"
+            ;;
+        *)
+            echo "USAGE: $0 [-f [true|false]] [-d] "
+            exit 1
+            ;;
     esac
+    shift
 done
 
 if [[ -f ${PID_FILE} ]] ; then

--- a/hugegraph-hubble/hubble-dist/assembly/static/bin/start-hubble.sh
+++ b/hugegraph-hubble/hubble-dist/assembly/static/bin/start-hubble.sh
@@ -46,11 +46,11 @@ JAVA_OPTS="-Xms512m -Dfile.encoding=UTF-8"
 JAVA_DEBUG_OPTS=""
 FOREGROUND="false"
 
-while getopts "f:d" arg; do
+while getopts "fd" arg; do
     case ${arg} in
-        f) FOREGROUND="$OPTARG" ;;
+        f) FOREGROUND="true" ;;
         d) JAVA_DEBUG_OPTS=" -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n" ;;
-        ?) echo "USAGE: $0 [-f true|false] [-d] " && exit 1 ;;
+        ?) echo "USAGE: $0 [-f] [-d] " && exit 1 ;;
     esac
 done
 
@@ -70,12 +70,12 @@ LOG=${LOG_PATH}/hugegraph-hubble.log
 
 if [[ $FOREGROUND == "false" ]]; then
     echo "Starting Hubble in daemon mode..."
-    nice -n 0 java -server ${JAVA_OPTS} ${JAVA_DEBUG_OPTS} -Dhubble.home.path="${HOME_PATH}" \
+    nohup nice -n 0 java -server ${JAVA_OPTS} ${JAVA_DEBUG_OPTS} -Dhubble.home.path="${HOME_PATH}" \
   -cp ${class_path} ${MAIN_CLASS} ${ARGS} > ${LOG} 2>&1 < /dev/null &
 else
     echo "Starting Hubble in foreground mode..."
-    nice -n 0 java -server ${JAVA_OPTS} ${JAVA_DEBUG_OPTS} -Dhubble.home.path="${HOME_PATH}" \
-  -cp ${class_path} ${MAIN_CLASS} ${ARGS} > ${LOG} 2>&1 < /dev/null
+    exec nice -n 0 java -server ${JAVA_OPTS} ${JAVA_DEBUG_OPTS} -Dhubble.home.path="${HOME_PATH}" \
+  -cp ${class_path} ${MAIN_CLASS} ${ARGS}
 fi
 
 PID=$!

--- a/hugegraph-hubble/hubble-dist/assembly/travis/check-hubble-dist.sh
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/check-hubble-dist.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 3 ]]; then
+    echo "Usage: $0 <apache-hugegraph-hubble-*.tar.gz> [--json-output <path>]" >&2
+    exit 1
+fi
+
+tarball=$1
+json_output=""
+if [[ $# -eq 3 ]]; then
+    if [[ "$2" != "--json-output" ]]; then
+        echo "Unknown option: $2" >&2
+        exit 1
+    fi
+    json_output=$3
+fi
+
+if [[ ! -f "${tarball}" ]]; then
+    echo "Hubble tarball not found: ${tarball}" >&2
+    exit 1
+fi
+
+tmp_list=$(mktemp)
+tmp_dir=$(mktemp -d)
+native_list=$(mktemp)
+trap 'rm -f "${tmp_list}" "${native_list}"; rm -rf "${tmp_dir}"' EXIT
+
+tar -tzf "${tarball}" > "${tmp_list}"
+root=$(sed -n '1s#/.*##p' "${tmp_list}")
+
+if [[ -z "${root}" ]]; then
+    echo "Unable to resolve tarball root directory" >&2
+    exit 1
+fi
+
+required_paths=(
+    "${root}/bin/"
+    "${root}/conf/"
+    "${root}/lib/"
+    "${root}/ui/"
+    "${root}/README.md"
+    "${root}/LICENSE"
+    "${root}/NOTICE"
+    "${root}/licenses/"
+)
+
+for path in "${required_paths[@]}"; do
+    if ! grep -qxF "${path}" "${tmp_list}"; then
+        echo "Missing required distribution path: ${path}" >&2
+        exit 1
+    fi
+done
+
+if ! grep -qE "^${root}/licenses/fe-licenses/" "${tmp_list}"; then
+    echo "Missing frontend license directory: ${root}/licenses/fe-licenses/" >&2
+    exit 1
+fi
+
+for residue in logs upload-files; do
+    if grep -qE "^${root}/${residue}(/|$)" "${tmp_list}"; then
+        echo "Runtime residue must not be packaged: ${residue}" >&2
+        exit 1
+    fi
+done
+
+blocked_patterns=(
+    "node_modules"
+    "\\.pid$"
+    "\\.lock$"
+    "\\.db$"
+    "\\.log$"
+)
+
+for pattern in "${blocked_patterns[@]}"; do
+    if grep -qE "(^|/)${pattern}(/|$)" "${tmp_list}"; then
+        echo "Blocked runtime/development artifact found: ${pattern}" >&2
+        grep -E "(^|/)${pattern}(/|$)" "${tmp_list}" >&2
+        exit 1
+    fi
+done
+
+if grep -qE "^${root}/ui/.*\\.map$" "${tmp_list}"; then
+    echo "Frontend source maps must not be packaged" >&2
+    grep -E "^${root}/ui/.*\\.map$" "${tmp_list}" >&2
+    exit 1
+fi
+
+unknown_binary_pattern="^${root}/.*\\.(so|dylib|dll|exe|bin|tar|tgz|gz|zip)$"
+if grep -qE "${unknown_binary_pattern}" "${tmp_list}"; then
+    echo "Unknown outer binary/archive files found in distribution" >&2
+    grep -E "${unknown_binary_pattern}" "${tmp_list}" >&2
+    exit 1
+fi
+
+jar_count=$(grep -cE "^${root}/lib/[^/]+\\.jar$" "${tmp_list}" || true)
+if [[ "${jar_count}" -eq 0 ]]; then
+    echo "No dependency jars found under ${root}/lib" >&2
+    exit 1
+fi
+
+license_count=$(grep -cE "^${root}/licenses/[^/]+$" "${tmp_list}" || true)
+fe_license_count=$(grep -cE "^${root}/licenses/fe-licenses/[^/]+$" \
+                   "${tmp_list}" || true)
+
+while IFS= read -r jar_path; do
+    local_jar="${tmp_dir}/$(basename "${jar_path}")"
+    tar -xOzf "${tarball}" "${jar_path}" > "${local_jar}"
+    if jar tf "${local_jar}" | grep -qE "\\.(so|dylib|dll|jnilib)$"; then
+        echo "${jar_path}" >> "${native_list}"
+    fi
+done < <(grep -E "^${root}/lib/[^/]+\\.jar$" "${tmp_list}")
+
+native_jar_count=$(wc -l < "${native_list}" | tr -d ' ')
+
+if [[ -n "${json_output}" ]]; then
+    mkdir -p "$(dirname "${json_output}")"
+    {
+        echo "{"
+        echo "  \"tarball\": \"${tarball}\","
+        echo "  \"root\": \"${root}\","
+        echo "  \"jar_count\": ${jar_count},"
+        echo "  \"license_count\": ${license_count},"
+        echo "  \"fe_license_count\": ${fe_license_count},"
+        echo "  \"native_jar_count\": ${native_jar_count},"
+        echo "  \"native_jars\": ["
+        sed 's#^#    "#; s#$#"#; $!s#$#,#' "${native_list}"
+        echo "  ]"
+        echo "}"
+    } > "${json_output}"
+fi
+
+echo "Hubble distribution check passed: ${tarball}"
+echo "JARs: ${jar_count}, license files: ${license_count}, FE license files: ${fe_license_count}, native-bearing JARs: ${native_jar_count}"

--- a/hugegraph-hubble/hubble-dist/assembly/travis/check-hubble-dist.sh
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/check-hubble-dist.sh
@@ -17,7 +17,7 @@
 #
 set -euo pipefail
 
-if [[ $# -lt 1 || $# -gt 3 ]]; then
+if [[ $# -ne 1 && $# -ne 3 ]]; then
     echo "Usage: $0 <apache-hugegraph-hubble-*.tar.gz> [--json-output <path>]" >&2
     exit 1
 fi
@@ -43,10 +43,30 @@ native_list=$(mktemp)
 trap 'rm -f "${tmp_list}" "${native_list}"; rm -rf "${tmp_dir}"' EXIT
 
 tar -tzf "${tarball}" > "${tmp_list}"
-root=$(sed -n '1s#/.*##p' "${tmp_list}")
 
-if [[ -z "${root}" ]]; then
+if grep -qE '(^/|(^|/)\.\.(/|$))' "${tmp_list}"; then
+    echo "Unsafe tarball path found; absolute paths and '..' are not allowed" >&2
+    grep -E '(^/|(^|/)\.\.(/|$))' "${tmp_list}" >&2
+    exit 1
+fi
+
+if tar -tvzf "${tarball}" | grep -qE '^[lh]'; then
+    echo "Tarball must not contain symbolic or hard links" >&2
+    tar -tvzf "${tarball}" | grep -E '^[lh]' >&2
+    exit 1
+fi
+
+root_count=$(awk -F/ 'NF > 0 && $1 != "" {print $1}' "${tmp_list}" | sort -u | wc -l | tr -d ' ')
+root=$(awk -F/ 'NF > 0 && $1 != "" {print $1; exit}' "${tmp_list}")
+
+if [[ -z "${root}" || "${root}" == "." ]]; then
     echo "Unable to resolve tarball root directory" >&2
+    exit 1
+fi
+
+if [[ "${root_count}" -ne 1 ]]; then
+    echo "Tarball must contain exactly one top-level root directory" >&2
+    awk -F/ 'NF > 0 && $1 != "" {print $1}' "${tmp_list}" | sort -u >&2
     exit 1
 fi
 
@@ -54,9 +74,14 @@ tar -xzf "${tarball}" -C "${tmp_dir}"
 
 required_paths=(
     "${root}/bin/"
+    "${root}/bin/start-hubble.sh"
+    "${root}/bin/stop-hubble.sh"
+    "${root}/bin/common_functions"
     "${root}/conf/"
+    "${root}/conf/hugegraph-hubble.properties"
     "${root}/lib/"
     "${root}/ui/"
+    "${root}/ui/index.html"
     "${root}/README.md"
     "${root}/LICENSE"
     "${root}/NOTICE"
@@ -91,10 +116,6 @@ done
 
 blocked_patterns=(
     "node_modules"
-    "\\.pid$"
-    "\\.lock$"
-    "\\.db$"
-    "\\.log$"
 )
 
 for pattern in "${blocked_patterns[@]}"; do
@@ -104,6 +125,13 @@ for pattern in "${blocked_patterns[@]}"; do
         exit 1
     fi
 done
+
+blocked_file_pattern="(^|/)(pid|[^/]+\\.(pid|lock|db|log))$"
+if grep -qE "${blocked_file_pattern}" "${tmp_list}"; then
+    echo "Blocked runtime/development file found" >&2
+    grep -E "${blocked_file_pattern}" "${tmp_list}" >&2
+    exit 1
+fi
 
 if grep -qE "^${root}/ui/.*\\.map$" "${tmp_list}"; then
     echo "Frontend source maps must not be packaged" >&2
@@ -127,6 +155,16 @@ fi
 license_count=$(grep -cE "^${root}/licenses/[^/]+$" "${tmp_list}" || true)
 fe_license_count=$(grep -cE "^${root}/licenses/fe-licenses/[^/]+$" \
                    "${tmp_list}" || true)
+
+if [[ "${license_count}" -eq 0 ]]; then
+    echo "No dependency license files found under ${root}/licenses" >&2
+    exit 1
+fi
+
+if [[ "${fe_license_count}" -eq 0 ]]; then
+    echo "No frontend license files found under ${root}/licenses/fe-licenses" >&2
+    exit 1
+fi
 
 while IFS= read -r jar_path; do
     local_jar="${tmp_dir}/${jar_path}"
@@ -174,4 +212,5 @@ if [[ -n "${json_output}" ]]; then
 fi
 
 echo "Hubble distribution check passed: ${tarball}"
-echo "JARs: ${jar_count}, license files: ${license_count}, FE license files: ${fe_license_count}, native-bearing JARs: ${native_jar_count}"
+printf 'JARs: %s, license files: %s, FE license files: %s, native-bearing JARs: %s\n' \
+       "${jar_count}" "${license_count}" "${fe_license_count}" "${native_jar_count}"

--- a/hugegraph-hubble/hubble-dist/assembly/travis/check-hubble-dist.sh
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/check-hubble-dist.sh
@@ -50,6 +50,8 @@ if [[ -z "${root}" ]]; then
     exit 1
 fi
 
+tar -xzf "${tarball}" -C "${tmp_dir}"
+
 required_paths=(
     "${root}/bin/"
     "${root}/conf/"
@@ -64,6 +66,13 @@ required_paths=(
 for path in "${required_paths[@]}"; do
     if ! grep -qxF "${path}" "${tmp_list}"; then
         echo "Missing required distribution path: ${path}" >&2
+        exit 1
+    fi
+done
+
+for legal_file in LICENSE NOTICE README.md; do
+    if [[ -z "$(tr -d '[:space:]' < "${tmp_dir}/${root}/${legal_file}")" ]]; then
+        echo "Packaged ${legal_file} must not be empty" >&2
         exit 1
     fi
 done
@@ -120,14 +129,30 @@ fe_license_count=$(grep -cE "^${root}/licenses/fe-licenses/[^/]+$" \
                    "${tmp_list}" || true)
 
 while IFS= read -r jar_path; do
-    local_jar="${tmp_dir}/$(basename "${jar_path}")"
-    tar -xOzf "${tarball}" "${jar_path}" > "${local_jar}"
+    local_jar="${tmp_dir}/${jar_path}"
     if jar tf "${local_jar}" | grep -qE "\\.(so|dylib|dll|jnilib)$"; then
         echo "${jar_path}" >> "${native_list}"
     fi
 done < <(grep -E "^${root}/lib/[^/]+\\.jar$" "${tmp_list}")
 
 native_jar_count=$(wc -l < "${native_list}" | tr -d ' ')
+checksum_status="not_checked"
+signature_status="not_checked"
+
+if [[ -f "${tarball}.sha512" ]]; then
+    expected_sha512=$(awk '{print $1}' "${tarball}.sha512")
+    actual_sha512=$(shasum -a 512 "${tarball}" | awk '{print $1}')
+    if [[ "${expected_sha512}" != "${actual_sha512}" ]]; then
+        echo "SHA-512 checksum mismatch for ${tarball}" >&2
+        exit 1
+    fi
+    checksum_status="passed"
+fi
+
+if [[ -f "${tarball}.asc" ]]; then
+    gpg --verify "${tarball}.asc" "${tarball}" >/dev/null 2>&1
+    signature_status="passed"
+fi
 
 if [[ -n "${json_output}" ]]; then
     mkdir -p "$(dirname "${json_output}")"
@@ -138,6 +163,8 @@ if [[ -n "${json_output}" ]]; then
         echo "  \"jar_count\": ${jar_count},"
         echo "  \"license_count\": ${license_count},"
         echo "  \"fe_license_count\": ${fe_license_count},"
+        echo "  \"checksum_status\": \"${checksum_status}\","
+        echo "  \"signature_status\": \"${signature_status}\","
         echo "  \"native_jar_count\": ${native_jar_count},"
         echo "  \"native_jars\": ["
         sed 's#^#    "#; s#$#"#; $!s#$#,#' "${native_list}"

--- a/hugegraph-hubble/hubble-dist/assembly/travis/start-hubble.sh
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/start-hubble.sh
@@ -33,6 +33,7 @@ PID_FILE=${BIN_PATH}/pid
 print_usage() {
     echo "  usage: start-hubble.sh [options]"
     echo "  options: "
+    echo "  -f,--foreground Start program in foreground mode"
     echo "  -d,--debug      Start program in debug mode"
     echo "  -h,--help       Display help information"
 }
@@ -50,11 +51,15 @@ for jar in "${LIB_PATH}"/*.jar; do
 done
 
 java_opts="-Xms512m"
+foreground="false"
 while [[ $# -gt 0 ]]; do
     case $1 in
         --help|-help|-h)
         print_usage
         exit 0
+        ;;
+        --foreground|-f)
+        foreground="true"
         ;;
         --debug|-d)
         java_opts="$java_opts -Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=y"
@@ -80,7 +85,11 @@ args=${CONF_PATH}/hugegraph-hubble.properties
 log=${LOG_PATH}/hugegraph-hubble.log
 
 echo -n "starting HugeGraphHubble "
-nohup nice -n 0 java -server -Dfile.encoding=UTF-8 "${java_opts}" "${agent_opts}" -Dhubble.home.path="${HOME_PATH}" -cp "${class_path}" ${main_class} "${args}" > "${log}" 2>&1 < /dev/null &
+if [[ ${foreground} == "false" ]]; then
+    nohup nice -n 0 java -server -Dfile.encoding=UTF-8 "${java_opts}" "${agent_opts}" -Dhubble.home.path="${HOME_PATH}" -cp "${class_path}" ${main_class} "${args}" > "${log}" 2>&1 < /dev/null &
+else
+    exec nice -n 0 java -server -Dfile.encoding=UTF-8 "${java_opts}" "${agent_opts}" -Dhubble.home.path="${HOME_PATH}" -cp "${class_path}" ${main_class} "${args}"
+fi
 pid=$!
 echo ${pid} > "${PID_FILE}"
 

--- a/hugegraph-hubble/hubble-dist/pom.xml
+++ b/hugegraph-hubble/hubble-dist/pom.xml
@@ -158,6 +158,7 @@
                                     rm -f ${final.name}/db.trace.db
                                     rm -f ${final.name}/*.pid
                                     rm -f ${final.name}/bin/pid
+                                    find ${final.name}/ui -name "*.map" -type f -delete
 
                                     tar -zcvf ${top.level.dir}/target/${final.name}.tar.gz ${final.name} || exit 1
                                     rm -rf ./hubble-dist/${final.name}

--- a/hugegraph-hubble/hubble-dist/pom.xml
+++ b/hugegraph-hubble/hubble-dist/pom.xml
@@ -161,6 +161,8 @@
                                     find ${final.name}/ui -name "*.map" -type f -delete
 
                                     tar -zcvf ${top.level.dir}/target/${final.name}.tar.gz ${final.name} || exit 1
+                                    bash ${assembly.dir}/travis/check-hubble-dist.sh \
+                                         ${top.level.dir}/target/${final.name}.tar.gz || exit 1
                                     rm -rf ./hubble-dist/${final.name}
                                     cp -r ${final.name} ./hubble-dist
                                     echo -n "${final.name} tar.gz available at: "

--- a/hugegraph-hubble/hubble-dist/pom.xml
+++ b/hugegraph-hubble/hubble-dist/pom.xml
@@ -29,10 +29,12 @@
         <release.name>${project.parent.artifactId}</release.name>
         <final.name>apache-${release.name}-${project.version}</final.name>
         <top.level.dir>${project.basedir}/..</top.level.dir>
+        <repo.root.dir>${top.level.dir}/..</repo.root.dir>
         <current.basedir>${project.basedir}</current.basedir>
         <assembly.dir>${current.basedir}/assembly</assembly.dir>
         <assembly.descriptor.dir>${assembly.dir}/descriptor</assembly.descriptor.dir>
         <assembly.static.dir>${assembly.dir}/static</assembly.static.dir>
+        <release.docs.dir>${repo.root.dir}/hugegraph-dist/release-docs</release.docs.dir>
         <hubble-fe.dir>${project.basedir}/../hubble-fe</hubble-fe.dir>
         <build.node.version>v18.20.8</build.node.version>
         <build.yarn.version>v1.22.21</build.yarn.version>
@@ -150,8 +152,15 @@
                                     cd ${top.level.dir} &amp;&amp; pwd
                                     rm -rf ${final.name}/ui
                                     cp -r ${hubble-fe.dir}/build ${final.name}/ui
+                                    rm -rf ${final.name}/logs
+                                    rm -rf ${final.name}/upload-files
+                                    rm -f ${final.name}/db.mv.db
+                                    rm -f ${final.name}/db.trace.db
+                                    rm -f ${final.name}/*.pid
+                                    rm -f ${final.name}/bin/pid
 
                                     tar -zcvf ${top.level.dir}/target/${final.name}.tar.gz ${final.name} || exit 1
+                                    rm -rf ./hubble-dist/${final.name}
                                     cp -r ${final.name} ./hubble-dist
                                     echo -n "${final.name} tar.gz available at: "
                                     echo "${top.level.dir}/target/${final.name}.tar.gz"


### PR DESCRIPTION
## Summary

This PR covers Feishu subtask 04: Hubble binary ASF compliance and dist audit.

It keeps the scope limited to Hubble distribution packaging and auditability:
- source `LICENSE`, `NOTICE`, and `licenses/**` from `hugegraph-dist/release-docs`
- remove runtime residue before creating the Hubble tarball (`logs/`, `upload-files/`, H2 db files, pid files)
- add `check-hubble-dist.sh` to validate required binary layout, legal bundle, FE license directory, blocked runtime/development artifacts, source maps, and native-bearing jars
- fix Hubble start scripts so foreground mode is `-f`/`--foreground` and does not redirect through daemon log handling

## Dependency

Draft until #12 is merged. The current `hubble2` baseline still has unrelated Hubble backend compile blockers; #12 contains the task 01/03 backend fixes and CI is already green there. After #12 lands, this PR should be rebased onto latest `hubble2` and converted to ready.

## Verification

- `git diff --check`
- `bash -n hugegraph-hubble/hubble-dist/assembly/travis/check-hubble-dist.sh`
- `bash -n hugegraph-hubble/hubble-dist/assembly/static/bin/start-hubble.sh`
- `bash -n hugegraph-hubble/hubble-dist/assembly/travis/start-hubble.sh`
- positive smoke tarball: `check-hubble-dist.sh` passed and wrote inventory JSON
- negative smoke tarball with `logs/`: `check-hubble-dist.sh` failed with `Runtime residue must not be packaged: logs`
- `mvn -pl hugegraph-hubble/hubble-dist validate -ntp`

Known baseline note:
- `mvn -pl hugegraph-hubble editorconfig:check -ntp` currently fails on existing `hubble-fe-old(legacy)` missing-final-newline files in `hubble2`; those files are handled in #12 and are intentionally not duplicated here.

Fixes part of #694.
