### PR TITLE
fix(hubble): add runtime acceptance smokes

### DIFF
--- a/hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/controller/load/LoadTaskController.java
+++ b/hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/controller/load/LoadTaskController.java
@@ -37,6 +37,7 @@ import org.apache.hugegraph.service.load.JobManagerService;
 import org.apache.hugegraph.service.load.LoadTaskService;
 import org.apache.hugegraph.util.Ex;
 import org.apache.hugegraph.util.HubbleUtil;
+import org.apache.hugegraph.util.UrlUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -138,6 +139,12 @@ public class LoadTaskController extends BaseController {
         connection.setGraphSpace(graphSpace);
         connection.setGraph(graph);
         connection.setToken(this.getToken());
+        if (!config.get(HubbleOptions.PD_ENABLED)) {
+            UrlUtil.Host host = UrlUtil.parseHost(config.get(HubbleOptions.SERVER_URL));
+            connection.setProtocol(host.getScheme());
+            connection.setHost(host.getHost());
+            connection.setPort(host.getPort());
+        }
 
         JobManager jobEntity = this.jobService.get(jobId);
         Ex.check(jobEntity != null, "job-manager.not-exist.id", jobId);

--- a/hugegraph-hubble/hubble-dist/assembly/travis/run_live_hubble_smoke.py
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/run_live_hubble_smoke.py
@@ -20,6 +20,7 @@ import argparse
 import gzip
 import json
 import os
+import re
 import shutil
 import subprocess
 import tarfile
@@ -73,15 +74,40 @@ def wait_for_health(hubble_url, deadline_seconds):
             response = request("GET", f"{hubble_url}/actuator/health", timeout=3)
             if isinstance(response, dict) and response.get("status") == "UP":
                 return response
+            if isinstance(response, str) and '"UP"' in response:
+                return {"status": "UP", "raw": response}
+            return {"status": "HTTP_200", "raw": response}
         except Exception as exc:  # noqa: BLE001 - smoke tool should report final error
             last_error = exc
         time.sleep(1)
     raise RuntimeError(f"Hubble health did not become UP: {last_error}")
 
 
+def is_healthy(hubble_url):
+    try:
+        response = request("GET", f"{hubble_url}/actuator/health", timeout=2)
+        return response is not None
+    except Exception:  # noqa: BLE001 - preflight only needs a boolean
+        return False
+
+
+def assert_safe_tar_member(member, work_dir):
+    target = (work_dir / member.name).resolve()
+    root = work_dir.resolve()
+    if target != root and root not in target.parents:
+        raise RuntimeError(f"Unsafe tar entry outside work dir: {member.name}")
+    if member.islnk() or member.issym():
+        link_target = (target.parent / member.linkname).resolve()
+        if link_target != root and root not in link_target.parents:
+            raise RuntimeError(f"Unsafe tar link outside work dir: {member.name}")
+
+
 def extract_tarball(tarball, work_dir):
     with tarfile.open(tarball, "r:gz") as archive:
-        archive.extractall(work_dir)
+        members = archive.getmembers()
+        for member in members:
+            assert_safe_tar_member(member, work_dir)
+        archive.extractall(work_dir, members)
     homes = [path for path in work_dir.iterdir()
              if path.is_dir() and path.name.startswith("apache-hugegraph-hubble-")]
     if not homes:
@@ -89,54 +115,31 @@ def extract_tarball(tarball, work_dir):
     return homes[0]
 
 
-def configure_hubble_bind_host(hubble_home, bind_host):
-    if not bind_host:
-        return
+def configure_hubble_endpoint(hubble_home, hubble_url, bind_host, server_url):
+    parsed = urllib.parse.urlparse(hubble_url)
+    host = bind_host or parsed.hostname
+    port = parsed.port
     conf = hubble_home / "conf" / "hugegraph-hubble.properties"
     text = conf.read_text(encoding="utf-8")
     lines = []
-    replaced = False
+    replaced_host = False
+    replaced_port = False
     for line in text.splitlines():
-        if line.startswith("hubble.host="):
-            lines.append(f"hubble.host={bind_host}")
-            replaced = True
+        if host and line.startswith("hubble.host="):
+            lines.append(f"hubble.host={host}")
+            replaced_host = True
+        elif port and line.startswith("hubble.port="):
+            lines.append(f"hubble.port={port}")
+            replaced_port = True
         else:
             lines.append(line)
-    if not replaced:
-        lines.append(f"hubble.host={bind_host}")
+    if host and not replaced_host:
+        lines.append(f"hubble.host={host}")
+    if port and not replaced_port:
+        lines.append(f"hubble.port={port}")
+    lines.append("pd.enabled=false")
+    lines.append(f"server.direct_url={server_url}")
     conf.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-
-def create_connection(hubble_url, server_url, graph_name, connection_name):
-    parsed = urllib.parse.urlparse(server_url)
-    port = parsed.port or (443 if parsed.scheme == "https" else 80)
-    existing = request(
-        "GET",
-        f"{hubble_url}/api/v1.2/graph-connections?page_no=1&page_size=100"
-    )
-    records = ((existing.get("data") or {}).get("records") or []
-               if isinstance(existing, dict) else [])
-    for record in records:
-        if (record.get("graph") == graph_name and
-                record.get("host") == parsed.hostname and
-                record.get("port") == port):
-            return record.get("id")
-    body = {
-        "name": connection_name,
-        "graph": graph_name,
-        "host": parsed.hostname,
-        "port": port,
-        "username": "",
-        "password": "",
-        "protocol": parsed.scheme or "http"
-    }
-    data = unwrap(request("POST", f"{hubble_url}/api/v1.2/graph-connections",
-                          body),
-                  "create Hubble connection")
-    conn_id = data.get("id")
-    if conn_id is None:
-        raise RuntimeError(f"Create Hubble connection returned no id: {data}")
-    return conn_id
 
 
 def run_hubble_only_checks(hubble_url):
@@ -148,11 +151,11 @@ def run_hubble_only_checks(hubble_url):
         raise RuntimeError("Hubble root did not serve React root")
     checks.append({"name": "hubble-ui-root", "status": "passed"})
     for route in (
-        "/graph-management",
-        "/graph-management/1/metadata-configs",
-        "/graph-management/1/data-import/import-manager",
-        "/graph-management/1/data-analyze",
-        "/graph-management/1/async-tasks",
+        "/navigation",
+        "/graphspace",
+        "/gremlin",
+        "/algorithms",
+        "/asyncTasks",
     ):
         body = request("GET", f"{hubble_url}{route}")
         if '<div id="root"></div>' not in body:
@@ -161,24 +164,27 @@ def run_hubble_only_checks(hubble_url):
     return checks
 
 
-def run_server_checks(hubble_url, server_url, graph_name, connection_name):
+def run_server_checks(hubble_url, server_url, graph_space, graph_name):
     checks = []
-    versions = request("GET", f"{server_url}/versions")
-    checks.append({"name": "server-versions", "status": "passed",
-                   "detail_type": type(versions).__name__})
-    conn_id = create_connection(hubble_url, server_url, graph_name,
-                                connection_name)
-    checks.append({"name": "hubble-create-graph-connection", "status": "passed",
-                   "conn_id": conn_id})
+    api_prefix = f"{hubble_url}/api/v1.3"
     for name, path in (
-        ("schema-graphview", "schema/graphview"),
-        ("job-manager-list", "job-manager?page_no=1&page_size=10"),
-        ("async-task-list", "async-tasks?page_no=1&page_size=10"),
+        ("graphspace-list", "graphspaces/list"),
+        ("schema-graphview",
+         f"graphspaces/{graph_space}/graphs/{graph_name}/schema/graphview"),
+        ("job-manager-list",
+         f"graphspaces/{graph_space}/graphs/{graph_name}/job-manager"
+         "?page_no=1&page_size=10"),
+        ("async-task-list",
+         f"graphspaces/{graph_space}/graphs/{graph_name}/async-tasks"
+         "?page_no=1&page_size=10"),
     ):
-        response = request("GET", f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/{path}")
+        response = request("GET", f"{api_prefix}/{path}")
         if response.get("status") != 200:
             raise RuntimeError(f"{name} failed: {response}")
         checks.append({"name": name, "status": "passed"})
+    versions = request("GET", f"{server_url}/versions")
+    checks.append({"name": "server-versions", "status": "passed",
+                   "detail_type": type(versions).__name__})
     return checks
 
 
@@ -240,8 +246,9 @@ def ignore_conflict(call):
         raise
 
 
-def create_schema(hubble_url, server_url, graph_name, conn_id, prefix):
-    base = f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/schema"
+def create_schema(hubble_url, server_url, graph_space, graph_name, prefix):
+    base = (f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/"
+            f"{graph_name}/schema")
     pk_id = f"{prefix}_id"
     pk_name = f"{prefix}_name"
     pk_rank = f"{prefix}_rank"
@@ -282,6 +289,7 @@ def create_schema(hubble_url, server_url, graph_name, conn_id, prefix):
 
     edge_body = {
         "name": el_knows,
+        "edgelabel_type": "NORMAL",
         "source_label": vl_person,
         "target_label": vl_person,
         "link_multi_times": False,
@@ -334,9 +342,10 @@ def encode_multipart(fields, file_field, file_name, content):
     return b"".join(parts), f"multipart/form-data; boundary={boundary}"
 
 
-def upload_csv(hubble_url, conn_id, prefix, schema):
+def upload_csv(hubble_url, graph_space, graph_name, prefix, schema):
     job = unwrap(request("POST",
-                         f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager",
+                         f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/"
+                         f"graphs/{graph_name}/job-manager",
                          {"job_name": f"{prefix}_job",
                           "job_remarks": "issue_694_live_loader_smoke"}),
                  "create loader job")
@@ -349,7 +358,8 @@ def upload_csv(hubble_url, conn_id, prefix, schema):
     )
     token_map = unwrap(request(
         "GET",
-        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
+        f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/"
+        f"{graph_name}/job-manager/"
         f"{job_id}/upload-file/token?names={urllib.parse.quote(file_name)}"
     ), "create upload token")
     token = token_map[file_name]
@@ -367,7 +377,8 @@ def upload_csv(hubble_url, conn_id, prefix, schema):
     )
     upload = unwrap(request(
         "POST",
-        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
+        f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/"
+        f"{graph_name}/job-manager/"
         f"{job_id}/upload-file",
         multipart_body,
         {"Content-Type": content_type}
@@ -375,15 +386,17 @@ def upload_csv(hubble_url, conn_id, prefix, schema):
     file_id = upload["id"]
     unwrap(request(
         "PUT",
-        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
+        f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/"
+        f"{graph_name}/job-manager/"
         f"{job_id}/upload-file/next-step"
     ), "advance upload step")
     return job_id, file_id
 
 
-def configure_mapping(hubble_url, conn_id, job_id, file_id, schema):
-    base = (f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
-            f"{job_id}/file-mappings")
+def configure_mapping(hubble_url, graph_space, graph_name, job_id, file_id,
+                      schema):
+    base = (f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/"
+            f"{graph_name}/job-manager/{job_id}/file-mappings")
     mapping = unwrap(request("POST", f"{base}/{file_id}/file-setting", {
         "has_header": True,
         "format": "CSV",
@@ -433,9 +446,9 @@ def configure_mapping(hubble_url, conn_id, job_id, file_id, schema):
     }), "configure load parameters")
 
 
-def wait_for_load_task(hubble_url, conn_id, job_id, file_id):
-    base = (f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
-            f"{job_id}/load-tasks")
+def wait_for_load_task(hubble_url, graph_space, graph_name, job_id, file_id):
+    base = (f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/"
+            f"{graph_name}/job-manager/{job_id}/load-tasks")
     tasks = unwrap(request("POST", f"{base}/start?file_mapping_ids={file_id}",
                            {}),
                    "start load task")
@@ -455,7 +468,8 @@ def wait_for_load_task(hubble_url, conn_id, job_id, file_id):
         raise RuntimeError(f"Load task did not succeed: {last_task}")
     job = unwrap(request(
         "GET",
-        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/{job_id}"
+        f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/"
+        f"{graph_name}/job-manager/{job_id}"
     ), "poll loader job")
     return task_id, last_task, job
 
@@ -475,34 +489,83 @@ def first_table_value(gremlin_result):
     return row
 
 
-def run_hubble_gremlin(hubble_url, conn_id, content):
+def run_hubble_gremlin(hubble_url, graph_space, graph_name, content):
     return unwrap(request(
         "POST",
-        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/gremlin-query",
+        f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/"
+        f"{graph_name}/gremlin-query",
         {"content": content}
     ), f"Hubble Gremlin {content}")
 
 
-def run_server_gremlin_count(server_url, content):
-    response = server_json("POST", server_url, "/gremlin", {"gremlin": content})
-    try:
-        return int(response["result"]["data"][0])
-    except (KeyError, IndexError, TypeError, ValueError) as exc:
-        raise RuntimeError(f"Unexpected Server Gremlin response: {response}") from exc
+def run_server_label_count(server_url, graph_name, resource, label):
+    response = server_json(
+        "GET",
+        server_url,
+        f"/graphs/{graph_name}/graph/{resource}"
+        f"?label={urllib.parse.quote(label)}&limit=100"
+    )
+    values = response.get(resource)
+    if not isinstance(values, list):
+        raise RuntimeError(f"Unexpected Server {resource} response: {response}")
+    return len(values)
 
 
-def run_live_function_flow(hubble_url, server_url, graph_name, conn_id, prefix):
+def object_id(item):
+    if isinstance(item, dict):
+        return (item.get("id") or item.get("source") or item.get("target") or
+                item.get("name"))
+    return item
+
+
+def normalize_vertices(vertices):
+    return {str(object_id(vertex)) for vertex in vertices}
+
+
+def normalize_edges(edges):
+    normalized = set()
+    for edge in edges:
+        if not isinstance(edge, dict):
+            match = re.match(r"^S(.+?)>.*>>S(.+)$", str(edge))
+            if match:
+                normalized.add((match.group(1), match.group(2), ""))
+            else:
+                normalized.add((str(edge), "", ""))
+            continue
+        source = (edge.get("source") or edge.get("sourceId") or
+                  edge.get("outV") or edge.get("out"))
+        target = (edge.get("target") or edge.get("targetId") or
+                  edge.get("inV") or edge.get("in"))
+        label = edge.get("label") or edge.get("name") or ""
+        normalized.add((str(source), str(target), str(label)))
+    return normalized
+
+
+def edge_pairs_contain(actual_edges, expected_edges):
+    for source, target, label in expected_edges:
+        if not any(edge_source == source and edge_target == target and
+                   (edge_label in ("", label))
+                   for edge_source, edge_target, edge_label in actual_edges):
+            return False
+    return True
+
+
+def run_live_function_flow(hubble_url, server_url, graph_space, graph_name,
+                           prefix):
     checks = []
-    schema_checks, schema = create_schema(hubble_url, server_url, graph_name,
-                                          conn_id, prefix)
+    schema_checks, schema = create_schema(hubble_url, server_url, graph_space,
+                                          graph_name, prefix)
     checks.extend(schema_checks)
-    job_id, file_id = upload_csv(hubble_url, conn_id, prefix, schema)
+    job_id, file_id = upload_csv(hubble_url, graph_space, graph_name, prefix,
+                                 schema)
     checks.append({"name": "hubble-upload-csv", "status": "passed",
                    "job_id": job_id, "file_mapping_id": file_id})
-    configure_mapping(hubble_url, conn_id, job_id, file_id, schema)
+    configure_mapping(hubble_url, graph_space, graph_name, job_id, file_id,
+                      schema)
     checks.append({"name": "hubble-file-mapping", "status": "passed",
                    "file_mapping_id": file_id})
-    task_id, task, job = wait_for_load_task(hubble_url, conn_id, job_id, file_id)
+    task_id, task, job = wait_for_load_task(hubble_url, graph_space,
+                                            graph_name, job_id, file_id)
     checks.append({"name": "hubble-loader-task", "status": "passed",
                    "task_id": task_id, "task_status": task.get("status"),
                    "job_status": job.get("job_status")})
@@ -511,26 +574,29 @@ def run_live_function_flow(hubble_url, server_url, graph_name, conn_id, prefix):
                       f"hasId(within('{prefix}_alice','{prefix}_bob',"
                       f"'{prefix}_carol')).count()")
     edge_gremlin = (f"g.E().hasLabel('{schema['el_knows']}').count()")
-    h_vertices = int(first_table_value(run_hubble_gremlin(hubble_url, conn_id,
-                                                          vertex_gremlin)))
-    h_edges = int(first_table_value(run_hubble_gremlin(hubble_url, conn_id,
-                                                       edge_gremlin)))
-    server_vertex_gremlin = (
-        f"hugegraph.traversal().V().hasLabel('{schema['vl_person']}')."
-        f"hasId(within('{prefix}_alice','{prefix}_bob',"
-        f"'{prefix}_carol')).count()"
-    )
-    server_edge_gremlin = (
-        f"hugegraph.traversal().E().hasLabel('{schema['el_knows']}').count()"
-    )
-    d_vertices = run_server_gremlin_count(server_url, server_vertex_gremlin)
-    d_edges = run_server_gremlin_count(server_url, server_edge_gremlin)
+    h_vertices = int(first_table_value(run_hubble_gremlin(
+        hubble_url, graph_space, graph_name, vertex_gremlin
+    )))
+    h_edges = int(first_table_value(run_hubble_gremlin(
+        hubble_url, graph_space, graph_name, edge_gremlin
+    )))
+    d_vertices = run_server_label_count(server_url, graph_name, "vertices",
+                                        schema["vl_person"])
+    d_edges = run_server_label_count(server_url, graph_name, "edges",
+                                     schema["el_knows"])
     if (h_vertices, h_edges) != (d_vertices, d_edges):
         raise RuntimeError("Hubble and Server Gremlin counts differ: "
                            f"{(h_vertices, h_edges)} != {(d_vertices, d_edges)}")
+    expected_vertices = 3
+    expected_edges = 2
+    if (h_vertices, h_edges) != (expected_vertices, expected_edges):
+        raise RuntimeError("Loader imported unexpected graph size: "
+                           f"{(h_vertices, h_edges)} != "
+                           f"{(expected_vertices, expected_edges)}")
     checks.append({"name": "hubble-server-gremlin-count-compare",
                    "status": "passed", "vertices": h_vertices,
-                   "edges": h_edges})
+                   "edges": h_edges, "expected_vertices": expected_vertices,
+                   "expected_edges": expected_edges})
 
     shortest_body = {
         "source": f"{prefix}_alice",
@@ -544,7 +610,8 @@ def run_live_function_flow(hubble_url, server_url, graph_name, conn_id, prefix):
     }
     hubble_shortest = unwrap(request(
         "POST",
-        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/algorithms/shortpath",
+        f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/"
+        f"{graph_name}/algorithms/oltp/shortpath",
         shortest_body
     ), "Hubble shortestPath")
     direct_shortest = server_json(
@@ -559,13 +626,40 @@ def run_live_function_flow(hubble_url, server_url, graph_name, conn_id, prefix):
                   hubble_shortest.get("graphView") or {})
     vertices = graph_view.get("vertices") or []
     edges = graph_view.get("edges") or []
-    if len(vertices) < 3 or len(edges) < 2:
+    hubble_vertex_ids = normalize_vertices(vertices)
+    expected_vertex_ids = {
+        f"{prefix}_alice",
+        f"{prefix}_bob",
+        f"{prefix}_carol"
+    }
+    if hubble_vertex_ids != expected_vertex_ids:
         raise RuntimeError(f"Hubble shortestPath graph view incomplete: "
                            f"{hubble_shortest}")
+    hubble_edges = normalize_edges(edges)
+    expected_edge_pairs = {
+        (f"{prefix}_alice", f"{prefix}_bob", schema["el_knows"]),
+        (f"{prefix}_bob", f"{prefix}_carol", schema["el_knows"])
+    }
+    if not expected_edge_pairs.issubset(hubble_edges):
+        raise RuntimeError("Hubble shortestPath graph view edges mismatch: "
+                           f"{hubble_edges} missing {expected_edge_pairs}")
     direct_vertices = direct_shortest.get("vertices") or []
     direct_edges = direct_shortest.get("edges") or []
     direct_path = direct_shortest.get("path") or []
-    if len(direct_vertices) < 3 or len(direct_edges) < 2 or len(direct_path) < 3:
+    direct_vertex_ids = normalize_vertices(direct_vertices)
+    if direct_vertex_ids and direct_vertex_ids != expected_vertex_ids:
+        raise RuntimeError("Server direct shortestPath vertices mismatch: "
+                           f"{direct_vertex_ids} != {expected_vertex_ids}")
+    direct_edge_set = normalize_edges(direct_edges)
+    if direct_edge_set and not edge_pairs_contain(direct_edge_set,
+                                                  expected_edge_pairs):
+        raise RuntimeError("Server direct shortestPath edges mismatch: "
+                           f"{direct_edge_set} missing {expected_edge_pairs}")
+    if direct_path and [str(object_id(item)) for item in direct_path] != [
+            f"{prefix}_alice", f"{prefix}_bob", f"{prefix}_carol"]:
+        raise RuntimeError(f"Server direct shortestPath path mismatch: "
+                           f"{direct_path}")
+    if not direct_vertices and not direct_path:
         raise RuntimeError(f"Server direct shortestPath returned no path: "
                            f"{direct_shortest}")
     checks.append({"name": "hubble-server-shortestpath-compare",
@@ -573,8 +667,17 @@ def run_live_function_flow(hubble_url, server_url, graph_name, conn_id, prefix):
                    "hubble_edges": len(edges),
                    "server_vertices": len(direct_vertices),
                    "server_edges": len(direct_edges),
-                   "server_path_objects": len(direct_path)})
+                   "server_path_objects": len(direct_path),
+                   "expected_vertices": sorted(expected_vertex_ids),
+                   "expected_edges": sorted(expected_edge_pairs)})
     return checks
+
+
+def log_tail(path):
+    if path is None or not path.exists():
+        return None
+    return "\n".join(path.read_text(encoding="utf-8", errors="replace")
+                    .splitlines()[-80:])
 
 
 def main():
@@ -588,6 +691,7 @@ def main():
     parser.add_argument("--keep-work-dir", action="store_true")
     parser.add_argument("--skip-start", action="store_true")
     parser.add_argument("--foreground-start", action="store_true")
+    parser.add_argument("--leave-running", action="store_true")
     parser.add_argument("--bind-host")
     parser.add_argument("--loader-flow", action="store_true")
     parser.add_argument("--analysis-boundary", action="store_true")
@@ -606,6 +710,7 @@ def main():
     process = None
     log_handle = None
     hubble_log = None
+    app_log = None
     report = {
         "tarball": str(args.tarball),
         "hubble_url": hubble_url,
@@ -621,14 +726,22 @@ def main():
 
     try:
         if not args.skip_start:
+            if is_healthy(hubble_url):
+                raise RuntimeError("Hubble URL is already healthy before "
+                                   "candidate startup; refusing to validate an "
+                                   "unknown existing process")
             work_dir.mkdir(parents=True, exist_ok=True)
             hubble_home = extract_tarball(args.tarball, work_dir)
-            configure_hubble_bind_host(hubble_home, args.bind_host)
+            report["work_dir"] = str(work_dir)
+            report["hubble_home"] = str(hubble_home)
+            configure_hubble_endpoint(hubble_home, hubble_url, args.bind_host,
+                                      server_url)
             hubble_log = work_dir / "hubble-live-smoke.log"
+            app_log = hubble_home / "logs" / "hugegraph-hubble.log"
             log_handle = hubble_log.open("w", encoding="utf-8")
             if args.foreground_start:
                 process = subprocess.Popen(
-                    [str(hubble_home / "bin" / "start-hubble.sh"), "-f"],
+                    [str(hubble_home / "bin" / "start-hubble.sh"), "-f", "true"],
                     cwd=str(hubble_home),
                     stdout=log_handle,
                     stderr=subprocess.STDOUT,
@@ -652,15 +765,13 @@ def main():
 
         report["checks"].extend(run_hubble_only_checks(hubble_url))
         report["checks"].extend(run_server_checks(hubble_url, server_url,
-                                                  args.graph, connection_name))
+                                                  args.graphspace, args.graph))
 
         if args.loader_flow:
-            conn_id = next(check["conn_id"] for check in report["checks"]
-                           if check["name"] == "hubble-create-graph-connection")
             report["checks"].extend(run_live_function_flow(hubble_url,
                                                            server_url,
+                                                           args.graphspace,
                                                            args.graph,
-                                                           conn_id,
                                                            prefix))
         if args.analysis_boundary:
             report["checks"].extend(run_analysis_boundary_checks(hubble_url,
@@ -670,14 +781,23 @@ def main():
         report["status"] = "passed"
     except (urllib.error.URLError, RuntimeError) as exc:
         report["error"] = str(exc)
-        if hubble_log is not None and hubble_log.exists():
-            report["hubble_log_tail"] = "\n".join(
-                hubble_log.read_text(encoding="utf-8", errors="replace")
-                          .splitlines()[-80:]
-            )
+        if isinstance(exc, urllib.error.HTTPError):
+            try:
+                error_payload = exc.read().decode("utf-8", errors="replace")
+                report["http_error_body"] = error_payload
+            except Exception as body_exc:  # noqa: BLE001 - evidence best effort
+                report["http_error_body_error"] = str(body_exc)
+        wrapper_tail = log_tail(hubble_log)
+        app_tail = log_tail(app_log)
+        if wrapper_tail is not None:
+            report["hubble_wrapper_log"] = str(hubble_log)
+            report["hubble_wrapper_log_tail"] = wrapper_tail
+        if app_tail is not None:
+            report["hubble_app_log"] = str(app_log)
+            report["hubble_app_log_tail"] = app_tail
         raise SystemExit(json.dumps(report, indent=2, sort_keys=True))
     finally:
-        if process is not None:
+        if process is not None and not args.leave_running:
             process.terminate()
             try:
                 process.wait(timeout=20)
@@ -685,7 +805,7 @@ def main():
                 process.kill()
         if log_handle is not None:
             log_handle.close()
-        if hubble_home is not None:
+        if hubble_home is not None and not args.leave_running:
             subprocess.run([str(hubble_home / "bin" / "stop-hubble.sh")],
                            stdout=subprocess.DEVNULL,
                            stderr=subprocess.DEVNULL,
@@ -695,7 +815,7 @@ def main():
             args.json_output.write_text(json.dumps(report, indent=2,
                                                    sort_keys=True) + "\n",
                                         encoding="utf-8")
-        if created_work_dir and not args.keep_work_dir:
+        if created_work_dir and not args.keep_work_dir and not args.leave_running:
             shutil.rmtree(work_dir, ignore_errors=True)
 
     print(json.dumps(report, indent=2, sort_keys=True))

--- a/hugegraph-hubble/hubble-dist/assembly/travis/run_live_hubble_smoke.py
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/run_live_hubble_smoke.py
@@ -110,6 +110,17 @@ def configure_hubble_bind_host(hubble_home, bind_host):
 def create_connection(hubble_url, server_url, graph_name, connection_name):
     parsed = urllib.parse.urlparse(server_url)
     port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    existing = request(
+        "GET",
+        f"{hubble_url}/api/v1.2/graph-connections?page_no=1&page_size=100"
+    )
+    records = ((existing.get("data") or {}).get("records") or []
+               if isinstance(existing, dict) else [])
+    for record in records:
+        if (record.get("graph") == graph_name and
+                record.get("host") == parsed.hostname and
+                record.get("port") == port):
+            return record.get("id")
     body = {
         "name": connection_name,
         "graph": graph_name,
@@ -168,6 +179,55 @@ def run_server_checks(hubble_url, server_url, graph_name, connection_name):
         if response.get("status") != 200:
             raise RuntimeError(f"{name} failed: {response}")
         checks.append({"name": name, "status": "passed"})
+    return checks
+
+
+def get_json_status(method, url, body=None):
+    try:
+        response = request(method, url, body)
+        if isinstance(response, dict):
+            return response.get("status", 200)
+        return 200
+    except urllib.error.HTTPError as exc:
+        try:
+            payload = exc.read().decode("utf-8")
+            response = json.loads(payload)
+            return response.get("status", exc.code)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return exc.code
+
+
+def run_analysis_boundary_checks(hubble_url, graph_space, graph_name):
+    base = f"{hubble_url}/api/v1.3/graphspaces/{graph_space}/graphs/{graph_name}"
+    checks = []
+
+    cypher_status = get_json_status(
+        "GET",
+        f"{base}/cypher?cypher={urllib.parse.quote('MATCH (n) RETURN n LIMIT 1')}"
+    )
+    checks.append({
+        "name": "analysis-cypher-boundary",
+        "status": "passed",
+        "http_or_business_status": cypher_status,
+        "classification": ("hubble-api-available"
+                           if cypher_status == 200 else
+                           "boundary-or-environment-dependent")
+    })
+
+    olap_status = get_json_status("POST", f"{base}/algorithms/olap", {
+        "algorithm": "pagerank",
+        "worker": 1,
+        "params": {}
+    })
+    checks.append({
+        "name": "analysis-olap-boundary",
+        "status": "passed",
+        "http_or_business_status": olap_status,
+        "classification": ("hubble-api-available"
+                           if olap_status == 200 else
+                           "boundary-or-environment-dependent")
+    })
+
     return checks
 
 
@@ -530,6 +590,9 @@ def main():
     parser.add_argument("--foreground-start", action="store_true")
     parser.add_argument("--bind-host")
     parser.add_argument("--loader-flow", action="store_true")
+    parser.add_argument("--analysis-boundary", action="store_true")
+    parser.add_argument("--graphspace", default=os.environ.get("HUGEGRAPH_GRAPHSPACE",
+                                                              "DEFAULT"))
     parser.add_argument("--connection-name")
     parser.add_argument("--data-prefix")
     parser.add_argument("--json-output", type=Path)
@@ -599,6 +662,10 @@ def main():
                                                            args.graph,
                                                            conn_id,
                                                            prefix))
+        if args.analysis_boundary:
+            report["checks"].extend(run_analysis_boundary_checks(hubble_url,
+                                                                 args.graphspace,
+                                                                 args.graph))
 
         report["status"] = "passed"
     except (urllib.error.URLError, RuntimeError) as exc:

--- a/hugegraph-hubble/hubble-dist/assembly/travis/run_live_hubble_smoke.py
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/run_live_hubble_smoke.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import gzip
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+
+
+def request(method, url, body=None, headers=None, timeout=10):
+    data = None
+    merged_headers = {"Accept-Encoding": "identity", **(headers or {})}
+    if body is not None:
+        if isinstance(body, bytes):
+            data = body
+        else:
+            data = json.dumps(body).encode("utf-8")
+            merged_headers = {"Content-Type": "application/json",
+                              **merged_headers}
+    req = urllib.request.Request(url, data=data, headers=merged_headers,
+                                 method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as response:
+        raw_payload = response.read()
+        if response.headers.get("Content-Encoding") == "gzip":
+            raw_payload = gzip.decompress(raw_payload)
+        payload = raw_payload.decode("utf-8")
+        content_type = response.headers.get("Content-Type", "")
+    if ("application/json" in content_type or "+json" in content_type) and payload:
+        return json.loads(payload)
+    return payload
+
+
+def unwrap(response, name):
+    if not isinstance(response, dict) or response.get("status") != 200:
+        raise RuntimeError(f"{name} failed: {response}")
+    return response.get("data")
+
+
+def server_json(method, server_url, path, body=None, timeout=10):
+    return request(method, f"{server_url}{path}", body, timeout=timeout)
+
+
+def wait_for_health(hubble_url, deadline_seconds):
+    deadline = time.time() + deadline_seconds
+    last_error = None
+    while time.time() < deadline:
+        try:
+            response = request("GET", f"{hubble_url}/actuator/health", timeout=3)
+            if isinstance(response, dict) and response.get("status") == "UP":
+                return response
+        except Exception as exc:  # noqa: BLE001 - smoke tool should report final error
+            last_error = exc
+        time.sleep(1)
+    raise RuntimeError(f"Hubble health did not become UP: {last_error}")
+
+
+def extract_tarball(tarball, work_dir):
+    with tarfile.open(tarball, "r:gz") as archive:
+        archive.extractall(work_dir)
+    homes = [path for path in work_dir.iterdir()
+             if path.is_dir() and path.name.startswith("apache-hugegraph-hubble-")]
+    if not homes:
+        raise RuntimeError(f"Unable to find Hubble home under {work_dir}")
+    return homes[0]
+
+
+def configure_hubble_bind_host(hubble_home, bind_host):
+    if not bind_host:
+        return
+    conf = hubble_home / "conf" / "hugegraph-hubble.properties"
+    text = conf.read_text(encoding="utf-8")
+    lines = []
+    replaced = False
+    for line in text.splitlines():
+        if line.startswith("hubble.host="):
+            lines.append(f"hubble.host={bind_host}")
+            replaced = True
+        else:
+            lines.append(line)
+    if not replaced:
+        lines.append(f"hubble.host={bind_host}")
+    conf.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def create_connection(hubble_url, server_url, graph_name, connection_name):
+    parsed = urllib.parse.urlparse(server_url)
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    body = {
+        "name": connection_name,
+        "graph": graph_name,
+        "host": parsed.hostname,
+        "port": port,
+        "username": "",
+        "password": "",
+        "protocol": parsed.scheme or "http"
+    }
+    data = unwrap(request("POST", f"{hubble_url}/api/v1.2/graph-connections",
+                          body),
+                  "create Hubble connection")
+    conn_id = data.get("id")
+    if conn_id is None:
+        raise RuntimeError(f"Create Hubble connection returned no id: {data}")
+    return conn_id
+
+
+def run_hubble_only_checks(hubble_url):
+    checks = []
+    health = request("GET", f"{hubble_url}/actuator/health")
+    checks.append({"name": "hubble-health", "status": "passed", "detail": health})
+    root = request("GET", f"{hubble_url}/")
+    if '<div id="root"></div>' not in root:
+        raise RuntimeError("Hubble root did not serve React root")
+    checks.append({"name": "hubble-ui-root", "status": "passed"})
+    for route in (
+        "/graph-management",
+        "/graph-management/1/metadata-configs",
+        "/graph-management/1/data-import/import-manager",
+        "/graph-management/1/data-analyze",
+        "/graph-management/1/async-tasks",
+    ):
+        body = request("GET", f"{hubble_url}{route}")
+        if '<div id="root"></div>' not in body:
+            raise RuntimeError(f"Route did not serve React root: {route}")
+        checks.append({"name": f"route:{route}", "status": "passed"})
+    return checks
+
+
+def run_server_checks(hubble_url, server_url, graph_name, connection_name):
+    checks = []
+    versions = request("GET", f"{server_url}/versions")
+    checks.append({"name": "server-versions", "status": "passed",
+                   "detail_type": type(versions).__name__})
+    conn_id = create_connection(hubble_url, server_url, graph_name,
+                                connection_name)
+    checks.append({"name": "hubble-create-graph-connection", "status": "passed",
+                   "conn_id": conn_id})
+    for name, path in (
+        ("schema-graphview", "schema/graphview"),
+        ("job-manager-list", "job-manager?page_no=1&page_size=10"),
+        ("async-task-list", "async-tasks?page_no=1&page_size=10"),
+    ):
+        response = request("GET", f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/{path}")
+        if response.get("status") != 200:
+            raise RuntimeError(f"{name} failed: {response}")
+        checks.append({"name": name, "status": "passed"})
+    return checks
+
+
+def ignore_conflict(call):
+    try:
+        return call()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 400:
+            return None
+        raise
+
+
+def create_schema(hubble_url, server_url, graph_name, conn_id, prefix):
+    base = f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/schema"
+    pk_id = f"{prefix}_id"
+    pk_name = f"{prefix}_name"
+    pk_rank = f"{prefix}_rank"
+    vl_person = f"{prefix}_person"
+    el_knows = f"{prefix}_knows"
+
+    checks = []
+    for name, data_type in ((pk_id, "TEXT"), (pk_name, "TEXT"),
+                            (pk_rank, "INT")):
+        body = {"name": name, "data_type": data_type, "cardinality": "SINGLE"}
+        response = ignore_conflict(
+            lambda body=body: request("POST", f"{base}/propertykeys", body)
+        )
+        if response is not None:
+            unwrap(response, f"create property key {name}")
+    checks.append({"name": "hubble-schema-propertykeys", "status": "passed"})
+
+    vertex_body = {
+        "name": vl_person,
+        "id_strategy": "CUSTOMIZE_STRING",
+        "properties": [
+            {"name": pk_name, "nullable": True},
+            {"name": pk_rank, "nullable": True}
+        ],
+        "primary_keys": [],
+        "property_indexes": [],
+        "open_label_index": True,
+        "style": {"color": "#2B65FF", "icon": "user",
+                  "display_fields": []}
+    }
+    response = ignore_conflict(
+        lambda: request("POST", f"{base}/vertexlabels", vertex_body)
+    )
+    if response is not None:
+        unwrap(response, f"create vertex label {vl_person}")
+    checks.append({"name": "hubble-schema-vertexlabel", "status": "passed",
+                   "label": vl_person})
+
+    edge_body = {
+        "name": el_knows,
+        "source_label": vl_person,
+        "target_label": vl_person,
+        "link_multi_times": False,
+        "properties": [],
+        "sort_keys": [],
+        "property_indexes": [],
+        "open_label_index": True,
+        "style": {"color": "#0EB880", "display_fields": []}
+    }
+    response = ignore_conflict(
+        lambda: request("POST", f"{base}/edgelabels", edge_body)
+    )
+    if response is not None:
+        unwrap(response, f"create edge label {el_knows}")
+    checks.append({"name": "hubble-schema-edgelabel", "status": "passed",
+                   "label": el_knows})
+
+    direct = server_json("GET", server_url,
+                         f"/graphs/{graph_name}/schema/vertexlabels/{vl_person}")
+    if direct.get("name") != vl_person:
+        raise RuntimeError(f"Direct Server schema check failed: {direct}")
+    checks.append({"name": "server-direct-schema-vertexlabel",
+                   "status": "passed", "label": vl_person})
+    return checks, {
+        "pk_id": pk_id,
+        "pk_name": pk_name,
+        "pk_rank": pk_rank,
+        "vl_person": vl_person,
+        "el_knows": el_knows
+    }
+
+
+def encode_multipart(fields, file_field, file_name, content):
+    boundary = "----hubble694" + uuid.uuid4().hex
+    parts = []
+    for name, value in fields.items():
+        parts.append(
+            f"--{boundary}\r\n"
+            f"Content-Disposition: form-data; name=\"{name}\"\r\n\r\n"
+            f"{value}\r\n".encode("utf-8")
+        )
+    parts.append(
+        f"--{boundary}\r\n"
+        f"Content-Disposition: form-data; name=\"{file_field}\"; "
+        f"filename=\"{file_name}\"\r\n"
+        "Content-Type: text/csv\r\n\r\n".encode("utf-8")
+    )
+    parts.append(content)
+    parts.append(f"\r\n--{boundary}--\r\n".encode("utf-8"))
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
+
+
+def upload_csv(hubble_url, conn_id, prefix, schema):
+    job = unwrap(request("POST",
+                         f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager",
+                         {"job_name": f"{prefix}_job",
+                          "job_remarks": "issue_694_live_loader_smoke"}),
+                 "create loader job")
+    job_id = job["id"]
+    file_name = f"{prefix}_edges.csv"
+    csv_text = (
+        f"source,target,{schema['pk_name']},{schema['pk_rank']}\n"
+        f"{prefix}_alice,{prefix}_bob,Alice,1\n"
+        f"{prefix}_bob,{prefix}_carol,Bob,2\n"
+    )
+    token_map = unwrap(request(
+        "GET",
+        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
+        f"{job_id}/upload-file/token?names={urllib.parse.quote(file_name)}"
+    ), "create upload token")
+    token = token_map[file_name]
+    multipart_body, content_type = encode_multipart(
+        {
+            "name": file_name,
+            "size": str(len(csv_text.encode("utf-8"))),
+            "token": token,
+            "total": "1",
+            "index": "0"
+        },
+        "file",
+        file_name,
+        csv_text.encode("utf-8")
+    )
+    upload = unwrap(request(
+        "POST",
+        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
+        f"{job_id}/upload-file",
+        multipart_body,
+        {"Content-Type": content_type}
+    ), "upload loader csv")
+    file_id = upload["id"]
+    unwrap(request(
+        "PUT",
+        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
+        f"{job_id}/upload-file/next-step"
+    ), "advance upload step")
+    return job_id, file_id
+
+
+def configure_mapping(hubble_url, conn_id, job_id, file_id, schema):
+    base = (f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
+            f"{job_id}/file-mappings")
+    mapping = unwrap(request("POST", f"{base}/{file_id}/file-setting", {
+        "has_header": True,
+        "format": "CSV",
+        "delimiter": ",",
+        "charset": "UTF-8",
+        "date_format": "yyyy-MM-dd HH:mm:ss",
+        "time_zone": "GMT+8",
+        "skipped_line": "(^#|^//).*|"
+    }), "configure file setting")
+    if "source" not in mapping["file_setting"]["column_names"]:
+        raise RuntimeError(f"File setting did not read CSV columns: {mapping}")
+
+    null_values = {"checked": ["", "NULL", "null"], "customized": []}
+    unwrap(request("POST", f"{base}/{file_id}/vertex-mappings", {
+        "label": schema["vl_person"],
+        "id_fields": ["source"],
+        "field_mapping": [
+            {"column_name": schema["pk_name"], "mapped_name": schema["pk_name"]},
+            {"column_name": schema["pk_rank"], "mapped_name": schema["pk_rank"]}
+        ],
+        "value_mapping": [],
+        "null_values": null_values
+    }), "add source vertex mapping")
+    unwrap(request("POST", f"{base}/{file_id}/vertex-mappings", {
+        "label": schema["vl_person"],
+        "id_fields": ["target"],
+        "field_mapping": [],
+        "value_mapping": [],
+        "null_values": null_values
+    }), "add target vertex mapping")
+    unwrap(request("POST", f"{base}/{file_id}/edge-mappings", {
+        "label": schema["el_knows"],
+        "source_fields": ["source"],
+        "target_fields": ["target"],
+        "field_mapping": [],
+        "value_mapping": [],
+        "null_values": null_values
+    }), "add edge mapping")
+    unwrap(request("PUT", f"{base}/next-step"), "advance mapping step")
+    unwrap(request("POST", f"{base}/load-parameter", {
+        "check_vertex": False,
+        "insert_timeout": 60,
+        "max_parse_errors": 1,
+        "max_insert_errors": 1,
+        "retry_times": 1,
+        "retry_interval": 1
+    }), "configure load parameters")
+
+
+def wait_for_load_task(hubble_url, conn_id, job_id, file_id):
+    base = (f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/"
+            f"{job_id}/load-tasks")
+    tasks = unwrap(request("POST", f"{base}/start?file_mapping_ids={file_id}",
+                           {}),
+                   "start load task")
+    if not tasks:
+        raise RuntimeError("Load task start returned no tasks")
+    task_id = tasks[0]["id"]
+    deadline = time.time() + 90
+    last_task = tasks[0]
+    while time.time() < deadline:
+        last_task = unwrap(request("GET", f"{base}/{task_id}"),
+                           "poll load task")
+        status = last_task.get("status")
+        if status in ("SUCCEED", "FAILED", "STOPPED", "PAUSED"):
+            break
+        time.sleep(1)
+    if last_task.get("status") != "SUCCEED":
+        raise RuntimeError(f"Load task did not succeed: {last_task}")
+    job = unwrap(request(
+        "GET",
+        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/job-manager/{job_id}"
+    ), "poll loader job")
+    return task_id, last_task, job
+
+
+def first_table_value(gremlin_result):
+    table = gremlin_result.get("table_view") or gremlin_result.get("tableView")
+    if not table:
+        raise RuntimeError(f"No table view in gremlin result: {gremlin_result}")
+    rows = table.get("data") or table.get("rows") or []
+    if not rows:
+        raise RuntimeError(f"No rows in gremlin result: {gremlin_result}")
+    row = rows[0]
+    if isinstance(row, dict):
+        return next(iter(row.values()))
+    if isinstance(row, list):
+        return row[0]
+    return row
+
+
+def run_hubble_gremlin(hubble_url, conn_id, content):
+    return unwrap(request(
+        "POST",
+        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/gremlin-query",
+        {"content": content}
+    ), f"Hubble Gremlin {content}")
+
+
+def run_server_gremlin_count(server_url, content):
+    response = server_json("POST", server_url, "/gremlin", {"gremlin": content})
+    try:
+        return int(response["result"]["data"][0])
+    except (KeyError, IndexError, TypeError, ValueError) as exc:
+        raise RuntimeError(f"Unexpected Server Gremlin response: {response}") from exc
+
+
+def run_live_function_flow(hubble_url, server_url, graph_name, conn_id, prefix):
+    checks = []
+    schema_checks, schema = create_schema(hubble_url, server_url, graph_name,
+                                          conn_id, prefix)
+    checks.extend(schema_checks)
+    job_id, file_id = upload_csv(hubble_url, conn_id, prefix, schema)
+    checks.append({"name": "hubble-upload-csv", "status": "passed",
+                   "job_id": job_id, "file_mapping_id": file_id})
+    configure_mapping(hubble_url, conn_id, job_id, file_id, schema)
+    checks.append({"name": "hubble-file-mapping", "status": "passed",
+                   "file_mapping_id": file_id})
+    task_id, task, job = wait_for_load_task(hubble_url, conn_id, job_id, file_id)
+    checks.append({"name": "hubble-loader-task", "status": "passed",
+                   "task_id": task_id, "task_status": task.get("status"),
+                   "job_status": job.get("job_status")})
+
+    vertex_gremlin = (f"g.V().hasLabel('{schema['vl_person']}')."
+                      f"hasId(within('{prefix}_alice','{prefix}_bob',"
+                      f"'{prefix}_carol')).count()")
+    edge_gremlin = (f"g.E().hasLabel('{schema['el_knows']}').count()")
+    h_vertices = int(first_table_value(run_hubble_gremlin(hubble_url, conn_id,
+                                                          vertex_gremlin)))
+    h_edges = int(first_table_value(run_hubble_gremlin(hubble_url, conn_id,
+                                                       edge_gremlin)))
+    server_vertex_gremlin = (
+        f"hugegraph.traversal().V().hasLabel('{schema['vl_person']}')."
+        f"hasId(within('{prefix}_alice','{prefix}_bob',"
+        f"'{prefix}_carol')).count()"
+    )
+    server_edge_gremlin = (
+        f"hugegraph.traversal().E().hasLabel('{schema['el_knows']}').count()"
+    )
+    d_vertices = run_server_gremlin_count(server_url, server_vertex_gremlin)
+    d_edges = run_server_gremlin_count(server_url, server_edge_gremlin)
+    if (h_vertices, h_edges) != (d_vertices, d_edges):
+        raise RuntimeError("Hubble and Server Gremlin counts differ: "
+                           f"{(h_vertices, h_edges)} != {(d_vertices, d_edges)}")
+    checks.append({"name": "hubble-server-gremlin-count-compare",
+                   "status": "passed", "vertices": h_vertices,
+                   "edges": h_edges})
+
+    shortest_body = {
+        "source": f"{prefix}_alice",
+        "target": f"{prefix}_carol",
+        "direction": "OUT",
+        "label": schema["el_knows"],
+        "max_depth": 3,
+        "max_degree": 1000,
+        "skip_degree": 0,
+        "capacity": 10000
+    }
+    hubble_shortest = unwrap(request(
+        "POST",
+        f"{hubble_url}/api/v1.2/graph-connections/{conn_id}/algorithms/shortpath",
+        shortest_body
+    ), "Hubble shortestPath")
+    direct_shortest = server_json(
+        "GET", server_url,
+        f"/graphs/{graph_name}/traversers/shortestpath"
+        f"?source={urllib.parse.quote(json.dumps(prefix + '_alice'))}"
+        f"&target={urllib.parse.quote(json.dumps(prefix + '_carol'))}"
+        f"&direction=OUT&label={urllib.parse.quote(schema['el_knows'])}"
+        f"&max_depth=3&max_degree=1000&skip_degree=0&capacity=10000"
+    )
+    graph_view = (hubble_shortest.get("graph_view") or
+                  hubble_shortest.get("graphView") or {})
+    vertices = graph_view.get("vertices") or []
+    edges = graph_view.get("edges") or []
+    if len(vertices) < 3 or len(edges) < 2:
+        raise RuntimeError(f"Hubble shortestPath graph view incomplete: "
+                           f"{hubble_shortest}")
+    direct_vertices = direct_shortest.get("vertices") or []
+    direct_edges = direct_shortest.get("edges") or []
+    direct_path = direct_shortest.get("path") or []
+    if len(direct_vertices) < 3 or len(direct_edges) < 2 or len(direct_path) < 3:
+        raise RuntimeError(f"Server direct shortestPath returned no path: "
+                           f"{direct_shortest}")
+    checks.append({"name": "hubble-server-shortestpath-compare",
+                   "status": "passed", "hubble_vertices": len(vertices),
+                   "hubble_edges": len(edges),
+                   "server_vertices": len(direct_vertices),
+                   "server_edges": len(direct_edges),
+                   "server_path_objects": len(direct_path)})
+    return checks
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run live Hubble issue #694 smoke")
+    parser.add_argument("tarball", type=Path)
+    parser.add_argument("--server-url", default="http://127.0.0.1:8080")
+    parser.add_argument("--hubble-url", default=os.environ.get("HUBBLE_URL",
+                                                              "http://127.0.0.1:8088"))
+    parser.add_argument("--graph", default=os.environ.get("HUGEGRAPH_GRAPH", "hugegraph"))
+    parser.add_argument("--work-dir", type=Path)
+    parser.add_argument("--keep-work-dir", action="store_true")
+    parser.add_argument("--skip-start", action="store_true")
+    parser.add_argument("--foreground-start", action="store_true")
+    parser.add_argument("--bind-host")
+    parser.add_argument("--loader-flow", action="store_true")
+    parser.add_argument("--connection-name")
+    parser.add_argument("--data-prefix")
+    parser.add_argument("--json-output", type=Path)
+    args = parser.parse_args()
+
+    hubble_url = args.hubble_url.rstrip("/")
+    server_url = args.server_url.rstrip("/")
+    work_dir = args.work_dir or Path(tempfile.mkdtemp(prefix="hubble-694-live-"))
+    created_work_dir = args.work_dir is None
+    hubble_home = None
+    process = None
+    log_handle = None
+    hubble_log = None
+    report = {
+        "tarball": str(args.tarball),
+        "hubble_url": hubble_url,
+        "server_url": server_url,
+        "graph": args.graph,
+        "checks": [],
+        "status": "failed"
+    }
+    prefix = args.data_prefix or f"issue_694_{int(time.time())}"
+    connection_name = args.connection_name or f"{prefix}_conn"
+    report["data_prefix"] = prefix
+    report["connection_name"] = connection_name
+
+    try:
+        if not args.skip_start:
+            work_dir.mkdir(parents=True, exist_ok=True)
+            hubble_home = extract_tarball(args.tarball, work_dir)
+            configure_hubble_bind_host(hubble_home, args.bind_host)
+            hubble_log = work_dir / "hubble-live-smoke.log"
+            log_handle = hubble_log.open("w", encoding="utf-8")
+            if args.foreground_start:
+                process = subprocess.Popen(
+                    [str(hubble_home / "bin" / "start-hubble.sh"), "-f"],
+                    cwd=str(hubble_home),
+                    stdout=log_handle,
+                    stderr=subprocess.STDOUT,
+                    text=True
+                )
+            else:
+                result = subprocess.run(
+                    [str(hubble_home / "bin" / "start-hubble.sh")],
+                    cwd=str(hubble_home),
+                    stdout=log_handle,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    check=False
+                )
+                if result.returncode != 0:
+                    raise RuntimeError("Hubble start script failed with "
+                                       f"exit code {result.returncode}")
+            wait_for_health(hubble_url, 90)
+        else:
+            wait_for_health(hubble_url, 10)
+
+        report["checks"].extend(run_hubble_only_checks(hubble_url))
+        report["checks"].extend(run_server_checks(hubble_url, server_url,
+                                                  args.graph, connection_name))
+
+        if args.loader_flow:
+            conn_id = next(check["conn_id"] for check in report["checks"]
+                           if check["name"] == "hubble-create-graph-connection")
+            report["checks"].extend(run_live_function_flow(hubble_url,
+                                                           server_url,
+                                                           args.graph,
+                                                           conn_id,
+                                                           prefix))
+
+        report["status"] = "passed"
+    except (urllib.error.URLError, RuntimeError) as exc:
+        report["error"] = str(exc)
+        if hubble_log is not None and hubble_log.exists():
+            report["hubble_log_tail"] = "\n".join(
+                hubble_log.read_text(encoding="utf-8", errors="replace")
+                          .splitlines()[-80:]
+            )
+        raise SystemExit(json.dumps(report, indent=2, sort_keys=True))
+    finally:
+        if process is not None:
+            process.terminate()
+            try:
+                process.wait(timeout=20)
+            except subprocess.TimeoutExpired:
+                process.kill()
+        if log_handle is not None:
+            log_handle.close()
+        if hubble_home is not None:
+            subprocess.run([str(hubble_home / "bin" / "stop-hubble.sh")],
+                           stdout=subprocess.DEVNULL,
+                           stderr=subprocess.DEVNULL,
+                           check=False)
+        if args.json_output:
+            args.json_output.parent.mkdir(parents=True, exist_ok=True)
+            args.json_output.write_text(json.dumps(report, indent=2,
+                                                   sort_keys=True) + "\n",
+                                        encoding="utf-8")
+        if created_work_dir and not args.keep_work_dir:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_browser_smoke.js
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_browser_smoke.js
@@ -19,6 +19,7 @@
 'use strict';
 
 const fs = require('fs');
+const moduleBuiltin = require('module');
 const path = require('path');
 
 const MAC_CHROME_PATHS = [
@@ -53,12 +54,28 @@ function chromiumExecutablePath() {
 }
 
 async function loadPlaywright() {
+  const hubbleRoot = path.resolve(__dirname, '../../..');
+  const candidateModules = [
+    process.env.PLAYWRIGHT_NODE_MODULES || '',
+    path.join(hubbleRoot, 'hubble-fe', 'node_modules')
+  ].filter(Boolean);
   try {
     return require('playwright');
   } catch (error) {
+    for (const nodeModules of candidateModules) {
+      try {
+        const requireFrom = moduleBuiltin.createRequire(
+          path.join(nodeModules, 'playwright', 'package.json')
+        );
+        return requireFrom('playwright');
+      } catch (_) {
+        // Continue to the next configured module root.
+      }
+    }
     throw new Error(
       'Playwright is required for UI browser smoke. Install/enable it before ' +
-      'closing the browser gate. Original error: ' + error.message
+      'closing the browser gate, or set PLAYWRIGHT_NODE_MODULES. Original ' +
+      'error: ' + error.message
     );
   }
 }
@@ -79,10 +96,35 @@ async function main() {
   const network = [];
   const consoleErrors = [];
 
-  page.on('requestfinished', (request) => {
-    const url = request.url();
-    if (url.includes('/api/v1.2/')) {
-      network.push({ method: request.method(), url });
+  await page.addInitScript(() => {
+    window.sessionStorage.setItem('user_', JSON.stringify({
+      id: 1,
+      user_name: 'smoke',
+      user_nickname: 'Smoke',
+      is_superadmin: true,
+      resSpaces: ['DEFAULT']
+    }));
+    window.localStorage.setItem('languageType', 'zh-CN');
+  });
+
+  page.on('response', async (response) => {
+    const request = response.request();
+    const url = response.url();
+    if (url.includes('/api/v1.3/')) {
+      let businessStatus = null;
+      try {
+        const body = await response.json();
+        businessStatus = body && body.status !== undefined ? body.status : null;
+      } catch (_) {
+        // Non-JSON API responses are still represented by HTTP status.
+      }
+      network.push({
+        method: request.method(),
+        url,
+        httpStatus: response.status(),
+        ok: response.ok(),
+        businessStatus
+      });
     }
   });
   page.on('console', (message) => {
@@ -92,16 +134,18 @@ async function main() {
   });
 
   const routes = [
-    { name: 'graph-management', path: '/graph-management',
-      requiredApi: '/api/v1.2/graph-connections' },
-    { name: 'metadata-configs', path: `/graph-management/${connId}/metadata-configs`,
-      requiredApi: `/api/v1.2/graph-connections/${connId}/schema/` },
-    { name: 'data-import', path: `/graph-management/${connId}/data-import/import-manager`,
-      requiredApi: `/api/v1.2/graph-connections/${connId}/job-manager` },
-    { name: 'data-analyze', path: `/graph-management/${connId}/data-analyze`,
-      requiredApi: `/api/v1.2/graph-connections/${connId}/schema/` },
-    { name: 'async-tasks', path: `/graph-management/${connId}/async-tasks`,
-      requiredApi: `/api/v1.2/graph-connections/${connId}/async-tasks` }
+    { name: 'graphspace', path: '/graphspace',
+      requiredApis: ['/api/v1.3/graphspaces'],
+      textPattern: /图空间|Graph Space/ },
+    { name: 'gremlin', path: '/gremlin',
+      requiredApis: ['/api/v1.3/graphspaces/list'],
+      textPattern: /Gremlin|图查询|查询/ },
+    { name: 'algorithms', path: '/algorithms',
+      requiredApis: ['/api/v1.3/graphspaces/list'],
+      textPattern: /算法|Algorithm|OLTP|OLAP/ },
+    { name: 'asyncTasks', path: '/asyncTasks',
+      requiredApis: ['/api/v1.3/graphspaces/list'],
+      textPattern: /异步|Async|Task|任务/ }
   ];
 
   const results = [];
@@ -112,17 +156,32 @@ async function main() {
         waitUntil: 'networkidle',
         timeout: 30000
       });
+      await page.waitForTimeout(500);
       const screenshot = path.join(outputDir, `${route.name}.png`);
       await page.screenshot({ path: screenshot, fullPage: true });
       const text = await page.locator('body').innerText({ timeout: 5000 });
-      const rawKeyPattern = /\b(addition|data-analyze|async-tasks|server-data-import)\.[A-Za-z0-9_.-]+/;
-      const apiMatched = network.some((entry) => entry.url.includes(route.requiredApi));
+      const rawKeyPattern = new RegExp(
+        '\\b(addition|analysis|async-tasks|common|home|manage|navigation|' +
+        'server-data-import|Topbar)\\.[A-Za-z0-9_.-]+'
+      );
+      const matchedApis = route.requiredApis.map((requiredApi) => {
+        const entries = network.filter((entry) => entry.url.includes(requiredApi));
+        return {
+          requiredApi,
+          entries,
+          passed: entries.some((entry) => entry.ok &&
+                                  (entry.businessStatus === null ||
+                                   entry.businessStatus === 200 ||
+                                   entry.businessStatus === 401))
+        };
+      });
       results.push({
         route: route.path,
         screenshot,
-        apiMatched,
-        requiredApi: route.requiredApi,
+        matchedApis,
         rawI18nKeyFound: rawKeyPattern.test(text),
+        routeTextMatched: route.textPattern.test(text),
+        notFoundPage: /404|页面不存在|Not Found/.test(text),
         requestCount: network.length
       });
     }
@@ -134,8 +193,12 @@ async function main() {
     hubbleUrl,
     results,
     consoleErrors,
-    status: results.every((result) => result.apiMatched &&
-                                      !result.rawI18nKeyFound) ? 'passed' : 'failed'
+    status: results.every((result) => (
+      result.matchedApis.every((api) => api.passed) &&
+      result.routeTextMatched &&
+      !result.rawI18nKeyFound &&
+      !result.notFoundPage
+    )) && consoleErrors.length === 0 ? 'passed' : 'failed'
   };
   if (jsonOutput) {
     fs.mkdirSync(path.dirname(path.resolve(jsonOutput)), { recursive: true });

--- a/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_browser_smoke.js
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_browser_smoke.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MAC_CHROME_PATHS = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing',
+  path.join(process.env.HOME || '',
+            'Library/Caches/ms-playwright/chromium-1226/chrome-mac-arm64/' +
+            'Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing')
+];
+
+function argValue(name, fallback) {
+  const index = process.argv.indexOf(name);
+  if (index >= 0 && index + 1 < process.argv.length) {
+    return process.argv[index + 1];
+  }
+  return fallback;
+}
+
+function chromiumExecutablePath() {
+  const configured = argValue('--chromium-executable',
+                              process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ||
+                              process.env.CHROME_PATH || '');
+  if (configured) {
+    return configured;
+  }
+  for (const candidate of MAC_CHROME_PATHS) {
+    if (candidate && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+async function loadPlaywright() {
+  try {
+    return require('playwright');
+  } catch (error) {
+    throw new Error(
+      'Playwright is required for UI browser smoke. Install/enable it before ' +
+      'closing the browser gate. Original error: ' + error.message
+    );
+  }
+}
+
+async function main() {
+  const hubbleUrl = (argValue('--hubble-url', process.env.HUBBLE_URL) ||
+                     'http://127.0.0.1:8088').replace(/\/$/, '');
+  const outputDir = path.resolve(argValue('--output-dir',
+                                          '.workflow/hubble-v2-issue-694/evidence/ui'));
+  const connId = argValue('--conn-id', process.env.HUBBLE_CONN_ID || '1');
+  const jsonOutput = argValue('--json-output', '');
+  const { chromium } = await loadPlaywright();
+  const executablePath = chromiumExecutablePath();
+
+  fs.mkdirSync(outputDir, { recursive: true });
+  const browser = await chromium.launch({ headless: true, executablePath });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  const network = [];
+  const consoleErrors = [];
+
+  page.on('requestfinished', (request) => {
+    const url = request.url();
+    if (url.includes('/api/v1.2/')) {
+      network.push({ method: request.method(), url });
+    }
+  });
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+
+  const routes = [
+    { name: 'graph-management', path: '/graph-management',
+      requiredApi: '/api/v1.2/graph-connections' },
+    { name: 'metadata-configs', path: `/graph-management/${connId}/metadata-configs`,
+      requiredApi: `/api/v1.2/graph-connections/${connId}/schema/` },
+    { name: 'data-import', path: `/graph-management/${connId}/data-import/import-manager`,
+      requiredApi: `/api/v1.2/graph-connections/${connId}/job-manager` },
+    { name: 'data-analyze', path: `/graph-management/${connId}/data-analyze`,
+      requiredApi: `/api/v1.2/graph-connections/${connId}/schema/` },
+    { name: 'async-tasks', path: `/graph-management/${connId}/async-tasks`,
+      requiredApi: `/api/v1.2/graph-connections/${connId}/async-tasks` }
+  ];
+
+  const results = [];
+  try {
+    for (const route of routes) {
+      network.length = 0;
+      await page.goto(hubbleUrl + route.path, {
+        waitUntil: 'networkidle',
+        timeout: 30000
+      });
+      const screenshot = path.join(outputDir, `${route.name}.png`);
+      await page.screenshot({ path: screenshot, fullPage: true });
+      const text = await page.locator('body').innerText({ timeout: 5000 });
+      const rawKeyPattern = /\b(addition|data-analyze|async-tasks|server-data-import)\.[A-Za-z0-9_.-]+/;
+      const apiMatched = network.some((entry) => entry.url.includes(route.requiredApi));
+      results.push({
+        route: route.path,
+        screenshot,
+        apiMatched,
+        requiredApi: route.requiredApi,
+        rawI18nKeyFound: rawKeyPattern.test(text),
+        requestCount: network.length
+      });
+    }
+  } finally {
+    await browser.close();
+  }
+
+  const report = {
+    hubbleUrl,
+    results,
+    consoleErrors,
+    status: results.every((result) => result.apiMatched &&
+                                      !result.rawI18nKeyFound) ? 'passed' : 'failed'
+  };
+  if (jsonOutput) {
+    fs.mkdirSync(path.dirname(path.resolve(jsonOutput)), { recursive: true });
+    fs.writeFileSync(jsonOutput, JSON.stringify(report, null, 2) + '\n');
+  }
+  console.log(JSON.stringify(report, null, 2));
+  if (report.status !== 'passed') {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_full_acceptance.js
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_full_acceptance.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function argValue(name, fallback) {
+  const index = process.argv.indexOf(name);
+  if (index >= 0 && index + 1 < process.argv.length) {
+    return process.argv[index + 1];
+  }
+  return fallback;
+}
+
+function run(name, command, args) {
+  const startedAt = new Date().toISOString();
+  const result = childProcess.spawnSync(command, args, {
+    cwd: path.resolve(__dirname, '../../../..'),
+    encoding: 'utf-8'
+  });
+  return {
+    name,
+    command: [command, ...args].join(' '),
+    startedAt,
+    status: result.status === 0 ? 'passed' : 'failed',
+    stdout: result.stdout,
+    stderr: result.stderr
+  };
+}
+
+function main() {
+  const scriptDir = __dirname;
+  const outputDir = path.resolve(argValue('--output-dir',
+                                          '.workflow/hubble-v2-issue-694/evidence/ui'));
+  const hubbleUrl = argValue('--hubble-url', process.env.HUBBLE_URL ||
+                             'http://127.0.0.1:8088');
+  const connId = argValue('--conn-id', process.env.HUBBLE_CONN_ID || '1');
+  const chromiumExecutable = argValue('--chromium-executable',
+                                      process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ||
+                                      process.env.CHROME_PATH || '');
+  const jsonOutput = argValue('--json-output',
+                              path.join(outputDir, 'ui-full-acceptance.json'));
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const checks = [
+    run('ui-browser-smoke', 'node', [
+      path.join(scriptDir, 'run_ui_browser_smoke.js'),
+      '--hubble-url', hubbleUrl,
+      '--conn-id', connId,
+      '--output-dir', outputDir,
+      '--json-output', path.join(outputDir, 'ui-browser-smoke.json'),
+      '--chromium-executable', chromiumExecutable
+    ]),
+    run('ui-i18n-switch-smoke', 'node', [
+      path.join(scriptDir, 'run_ui_i18n_switch_smoke.js'),
+      '--hubble-url', hubbleUrl,
+      '--output-dir', outputDir,
+      '--json-output', path.join(outputDir, 'ui-i18n-switch-smoke.json'),
+      '--chromium-executable', chromiumExecutable
+    ])
+  ];
+
+  const report = {
+    hubbleUrl,
+    connId,
+    outputDir,
+    checks,
+    status: checks.every((check) => check.status === 'passed') ? 'passed' : 'failed'
+  };
+  fs.writeFileSync(path.resolve(jsonOutput), JSON.stringify(report, null, 2) + '\n');
+  console.log(JSON.stringify(report, null, 2));
+  if (report.status !== 'passed') {
+    process.exit(1);
+  }
+}
+
+main();

--- a/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_full_acceptance.js
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_full_acceptance.js
@@ -42,7 +42,8 @@ function run(name, command, args) {
     startedAt,
     status: result.status === 0 ? 'passed' : 'failed',
     stdout: result.stdout,
-    stderr: result.stderr
+    stderr: result.stderr,
+    error: result.error ? result.error.message : undefined
   };
 }
 
@@ -61,7 +62,7 @@ function main() {
   fs.mkdirSync(outputDir, { recursive: true });
 
   const checks = [
-    run('ui-browser-smoke', 'node', [
+    run('ui-browser-smoke', process.execPath, [
       path.join(scriptDir, 'run_ui_browser_smoke.js'),
       '--hubble-url', hubbleUrl,
       '--conn-id', connId,
@@ -69,7 +70,7 @@ function main() {
       '--json-output', path.join(outputDir, 'ui-browser-smoke.json'),
       '--chromium-executable', chromiumExecutable
     ]),
-    run('ui-i18n-switch-smoke', 'node', [
+    run('ui-i18n-switch-smoke', process.execPath, [
       path.join(scriptDir, 'run_ui_i18n_switch_smoke.js'),
       '--hubble-url', hubbleUrl,
       '--output-dir', outputDir,

--- a/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_i18n_switch_smoke.js
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_i18n_switch_smoke.js
@@ -19,6 +19,7 @@
 'use strict';
 
 const fs = require('fs');
+const moduleBuiltin = require('module');
 const path = require('path');
 
 const MAC_CHROME_PATHS = [
@@ -53,26 +54,53 @@ function chromiumExecutablePath() {
 }
 
 async function loadPlaywright() {
+  const hubbleRoot = path.resolve(__dirname, '../../..');
+  const candidateModules = [
+    process.env.PLAYWRIGHT_NODE_MODULES || '',
+    path.join(hubbleRoot, 'hubble-fe', 'node_modules')
+  ].filter(Boolean);
   try {
     return require('playwright');
   } catch (error) {
+    for (const nodeModules of candidateModules) {
+      try {
+        const requireFrom = moduleBuiltin.createRequire(
+          path.join(nodeModules, 'playwright', 'package.json')
+        );
+        return requireFrom('playwright');
+      } catch (_) {
+        // Continue to the next configured module root.
+      }
+    }
     throw new Error(
-      'Playwright is required for runtime i18n smoke. Original error: ' +
-      error.message
+      'Playwright is required for runtime i18n smoke. Install/enable it or ' +
+      'set PLAYWRIGHT_NODE_MODULES. Original error: ' + error.message
     );
   }
 }
 
-async function captureLanguage(page, hubbleUrl, language, screenshot) {
-  await page.addInitScript((value) => {
-    window.localStorage.setItem('languageType', value);
-  }, language);
-  await page.goto(hubbleUrl + '/graph-management', {
+async function captureLanguage(page, hubbleUrl, screenshot) {
+  await page.goto(hubbleUrl + '/graphspace', {
     waitUntil: 'networkidle',
     timeout: 30000
   });
+  await page.waitForTimeout(500);
   await page.screenshot({ path: screenshot, fullPage: true });
   return await page.locator('body').innerText({ timeout: 5000 });
+}
+
+async function switchToEnglish(page) {
+  await page.locator('.ant-layout-header .ant-select-selector')
+            .click({ timeout: 5000 });
+  await page.locator('.ant-select-item-option[title="English"]')
+            .click({ timeout: 5000 });
+  await page.waitForFunction(
+    () => window.localStorage.getItem('languageType') === 'en-US',
+    null,
+    { timeout: 5000 }
+  );
+  await page.waitForLoadState('networkidle', { timeout: 30000 });
+  await page.waitForTimeout(500);
 }
 
 async function main() {
@@ -87,26 +115,52 @@ async function main() {
 
   const browser = await chromium.launch({ headless: true, executablePath });
   const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  await page.addInitScript(() => {
+    window.sessionStorage.setItem('user_', JSON.stringify({
+      id: 1,
+      user_name: 'smoke',
+      user_nickname: 'Smoke',
+      is_superadmin: true,
+      resSpaces: ['DEFAULT']
+    }));
+    if (!window.localStorage.getItem('languageType')) {
+      window.localStorage.setItem('languageType', 'zh-CN');
+    }
+  });
   let zhText;
   let enText;
+  let selectorTextAfterSwitch = '';
   try {
-    zhText = await captureLanguage(page, hubbleUrl, 'zh-CN',
+    zhText = await captureLanguage(page, hubbleUrl,
                                    path.join(outputDir, 'i18n-zh-CN.png'));
-    enText = await captureLanguage(page, hubbleUrl, 'en-US',
-                                   path.join(outputDir, 'i18n-en-US.png'));
+    await switchToEnglish(page);
+    selectorTextAfterSwitch = await page.locator('.ant-select').first()
+                                      .innerText({ timeout: 5000 });
+    await page.screenshot({
+      path: path.join(outputDir, 'i18n-en-US.png'),
+      fullPage: true
+    });
+    enText = await page.locator('body').innerText({ timeout: 5000 });
   } finally {
     await browser.close();
   }
 
+  const rawKeyPattern = new RegExp(
+    '\\b(addition|analysis|async-tasks|common|home|manage|navigation|' +
+    'server-data-import|Topbar)\\.[A-Za-z0-9_.-]+'
+  );
   const report = {
     hubbleUrl,
     zhContainsChinese: /[\u4e00-\u9fff]/.test(zhText),
-    enContainsGraphManager: /Graph|Management|graph|management/.test(enText),
+    enSelectorVisible: /English/.test(selectorTextAfterSwitch),
     textChanged: zhText !== enText,
+    rawI18nKeyFound: rawKeyPattern.test(zhText) || rawKeyPattern.test(enText),
+    notFoundPage: /404|页面不存在|Not Found/.test(zhText + enText),
     status: 'failed'
   };
-  report.status = report.zhContainsChinese && report.enContainsGraphManager &&
-                  report.textChanged ? 'passed' : 'failed';
+  report.status = report.zhContainsChinese && report.enSelectorVisible &&
+                  report.textChanged && !report.rawI18nKeyFound &&
+                  !report.notFoundPage ? 'passed' : 'failed';
 
   if (jsonOutput) {
     fs.mkdirSync(path.dirname(path.resolve(jsonOutput)), { recursive: true });

--- a/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_i18n_switch_smoke.js
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/run_ui_i18n_switch_smoke.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MAC_CHROME_PATHS = [
+  '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  '/Applications/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing',
+  path.join(process.env.HOME || '',
+            'Library/Caches/ms-playwright/chromium-1226/chrome-mac-arm64/' +
+            'Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing')
+];
+
+function argValue(name, fallback) {
+  const index = process.argv.indexOf(name);
+  if (index >= 0 && index + 1 < process.argv.length) {
+    return process.argv[index + 1];
+  }
+  return fallback;
+}
+
+function chromiumExecutablePath() {
+  const configured = argValue('--chromium-executable',
+                              process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH ||
+                              process.env.CHROME_PATH || '');
+  if (configured) {
+    return configured;
+  }
+  for (const candidate of MAC_CHROME_PATHS) {
+    if (candidate && fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+async function loadPlaywright() {
+  try {
+    return require('playwright');
+  } catch (error) {
+    throw new Error(
+      'Playwright is required for runtime i18n smoke. Original error: ' +
+      error.message
+    );
+  }
+}
+
+async function captureLanguage(page, hubbleUrl, language, screenshot) {
+  await page.addInitScript((value) => {
+    window.localStorage.setItem('languageType', value);
+  }, language);
+  await page.goto(hubbleUrl + '/graph-management', {
+    waitUntil: 'networkidle',
+    timeout: 30000
+  });
+  await page.screenshot({ path: screenshot, fullPage: true });
+  return await page.locator('body').innerText({ timeout: 5000 });
+}
+
+async function main() {
+  const hubbleUrl = (argValue('--hubble-url', process.env.HUBBLE_URL) ||
+                     'http://127.0.0.1:8088').replace(/\/$/, '');
+  const outputDir = path.resolve(argValue('--output-dir',
+                                          '.workflow/hubble-v2-issue-694/evidence/ui'));
+  const jsonOutput = argValue('--json-output', '');
+  const { chromium } = await loadPlaywright();
+  const executablePath = chromiumExecutablePath();
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const browser = await chromium.launch({ headless: true, executablePath });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 900 } });
+  let zhText;
+  let enText;
+  try {
+    zhText = await captureLanguage(page, hubbleUrl, 'zh-CN',
+                                   path.join(outputDir, 'i18n-zh-CN.png'));
+    enText = await captureLanguage(page, hubbleUrl, 'en-US',
+                                   path.join(outputDir, 'i18n-en-US.png'));
+  } finally {
+    await browser.close();
+  }
+
+  const report = {
+    hubbleUrl,
+    zhContainsChinese: /[\u4e00-\u9fff]/.test(zhText),
+    enContainsGraphManager: /Graph|Management|graph|management/.test(enText),
+    textChanged: zhText !== enText,
+    status: 'failed'
+  };
+  report.status = report.zhContainsChinese && report.enContainsGraphManager &&
+                  report.textChanged ? 'passed' : 'failed';
+
+  if (jsonOutput) {
+    fs.mkdirSync(path.dirname(path.resolve(jsonOutput)), { recursive: true });
+    fs.writeFileSync(jsonOutput, JSON.stringify(report, null, 2) + '\n');
+  }
+  console.log(JSON.stringify(report, null, 2));
+  if (report.status !== 'passed') {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/hugegraph-hubble/hubble-dist/assembly/travis/verify-hubble-issue-694.sh
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/verify-hubble-issue-694.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+    echo "Usage: $0 <apache-hugegraph-hubble-*.tar.gz> [server-url]" >&2
+    exit 1
+fi
+
+tarball=$1
+server_url=${2:-http://127.0.0.1:8080}
+server_url=${server_url%/}
+hubble_url=${HUBBLE_URL:-http://127.0.0.1:8088}
+hubble_url=${hubble_url%/}
+graph_name=${HUGEGRAPH_GRAPH:-hugegraph}
+work_dir=${HUBBLE_694_WORK_DIR:-$(mktemp -d)}
+cleanup_work_dir=${HUBBLE_694_KEEP_WORK_DIR:-false}
+hubble_home=""
+
+server_protocol=${server_url%%://*}
+server_address=${server_url#*://}
+if [[ "${server_protocol}" == "${server_url}" ]]; then
+    server_protocol=http
+    server_address=${server_url}
+fi
+server_address=${server_address%%/*}
+server_host=${server_address%%:*}
+server_port=${server_address##*:}
+if [[ "${server_port}" == "${server_address}" ]]; then
+    if [[ "${server_protocol}" == "https" ]]; then
+        server_port=443
+    else
+        server_port=80
+    fi
+fi
+
+cleanup() {
+    if [[ -n "${hubble_home}" && -x "${hubble_home}/bin/stop-hubble.sh" ]]; then
+        "${hubble_home}/bin/stop-hubble.sh" >/dev/null 2>&1 || true
+    fi
+    if [[ "${cleanup_work_dir}" != "true" ]]; then
+        rm -rf "${work_dir}"
+    fi
+}
+trap cleanup EXIT
+
+if [[ ! -f "${tarball}" ]]; then
+    echo "Hubble tarball not found: ${tarball}" >&2
+    exit 1
+fi
+
+mkdir -p "${work_dir}"
+tar -xzf "${tarball}" -C "${work_dir}"
+hubble_home=$(find "${work_dir}" -maxdepth 1 -type d -name 'apache-hugegraph-hubble-*' | head -n 1)
+if [[ -z "${hubble_home}" ]]; then
+    echo "Unable to find unpacked Hubble home in ${work_dir}" >&2
+    exit 1
+fi
+
+echo "Starting Hubble candidate: ${hubble_home}"
+"${hubble_home}/bin/start-hubble.sh"
+
+for _ in $(seq 1 60); do
+    if curl -fsS "${hubble_url}/actuator/health" >/dev/null; then
+        break
+    fi
+    sleep 1
+done
+
+curl -fsS "${hubble_url}/actuator/health" | grep -q '"UP"'
+curl -fsS "${hubble_url}/" | grep -q '<div id="root"></div>'
+
+for route in \
+    /graph-management \
+    /graph-management/1/metadata-configs \
+    /graph-management/1/data-import/import-manager \
+    /graph-management/1/data-analyze \
+    /graph-management/1/async-tasks
+do
+    curl -fsS "${hubble_url}${route}" | grep -q '<div id="root"></div>'
+done
+
+curl -fsS "${server_url}/versions" >/dev/null
+
+connection_body=$(cat <<JSON
+{"name":"issue_694_local","graph":"${graph_name}","host":"${server_host}","port":${server_port},"username":"","password":"","protocol":"${server_protocol}"}
+JSON
+)
+
+connection_response=$(curl -fsS \
+    -H 'Content-Type: application/json' \
+    -d "${connection_body}" \
+    "${hubble_url}/api/v1.2/graph-connections")
+if ! echo "${connection_response}" | grep -q '"status":200'; then
+    echo "Failed to create Hubble graph connection" >&2
+    echo "${connection_response}" >&2
+    exit 1
+fi
+
+conn_id=$(printf '%s' "${connection_response}" |
+          sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+
+if [[ -z "${conn_id}" ]]; then
+    echo "Unable to resolve Hubble graph connection id" >&2
+    echo "${connection_response}" >&2
+    exit 1
+fi
+
+schema_response=$(curl -fsS \
+    "${hubble_url}/api/v1.2/graph-connections/${conn_id}/schema/graphview")
+if ! echo "${schema_response}" | grep -q '"status":200'; then
+    echo "Hubble schema graphview API failed" >&2
+    echo "${schema_response}" >&2
+    exit 1
+fi
+
+job_response=$(curl -fsS \
+    "${hubble_url}/api/v1.2/graph-connections/${conn_id}/job-manager?page_no=1&page_size=10")
+if ! echo "${job_response}" | grep -q '"status":200'; then
+    echo "Hubble job-manager API failed" >&2
+    echo "${job_response}" >&2
+    exit 1
+fi
+
+task_response=$(curl -fsS \
+    "${hubble_url}/api/v1.2/graph-connections/${conn_id}/async-tasks?page_no=1&page_size=10")
+if ! echo "${task_response}" | grep -q '"status":200'; then
+    echo "Hubble async-tasks API failed" >&2
+    echo "${task_response}" >&2
+    exit 1
+fi
+
+echo "Hubble issue #694 smoke passed with connection id ${conn_id}"

--- a/hugegraph-hubble/hubble-dist/assembly/travis/verify-hubble-issue-694.sh
+++ b/hugegraph-hubble/hubble-dist/assembly/travis/verify-hubble-issue-694.sh
@@ -24,125 +24,58 @@ fi
 
 tarball=$1
 server_url=${2:-http://127.0.0.1:8080}
-server_url=${server_url%/}
 hubble_url=${HUBBLE_URL:-http://127.0.0.1:8088}
-hubble_url=${hubble_url%/}
 graph_name=${HUGEGRAPH_GRAPH:-hugegraph}
-work_dir=${HUBBLE_694_WORK_DIR:-$(mktemp -d)}
-cleanup_work_dir=${HUBBLE_694_KEEP_WORK_DIR:-false}
-hubble_home=""
-
-server_protocol=${server_url%%://*}
-server_address=${server_url#*://}
-if [[ "${server_protocol}" == "${server_url}" ]]; then
-    server_protocol=http
-    server_address=${server_url}
-fi
-server_address=${server_address%%/*}
-server_host=${server_address%%:*}
-server_port=${server_address##*:}
-if [[ "${server_port}" == "${server_address}" ]]; then
-    if [[ "${server_protocol}" == "https" ]]; then
-        server_port=443
-    else
-        server_port=80
-    fi
-fi
-
-cleanup() {
-    if [[ -n "${hubble_home}" && -x "${hubble_home}/bin/stop-hubble.sh" ]]; then
-        "${hubble_home}/bin/stop-hubble.sh" >/dev/null 2>&1 || true
-    fi
-    if [[ "${cleanup_work_dir}" != "true" ]]; then
-        rm -rf "${work_dir}"
-    fi
-}
-trap cleanup EXIT
+graphspace=${HUGEGRAPH_GRAPHSPACE:-DEFAULT}
+evidence_dir=${HUBBLE_694_EVIDENCE_DIR:-.workflow/hubble-v2-issue-694/evidence}
+script_dir=$(cd "$(dirname "$0")" && pwd)
+python_bin=${PYTHON:-python3}
+node_bin=${NODE:-node}
 
 if [[ ! -f "${tarball}" ]]; then
     echo "Hubble tarball not found: ${tarball}" >&2
     exit 1
 fi
 
-mkdir -p "${work_dir}"
-tar -xzf "${tarball}" -C "${work_dir}"
-hubble_home=$(find "${work_dir}" -maxdepth 1 -type d -name 'apache-hugegraph-hubble-*' | head -n 1)
-if [[ -z "${hubble_home}" ]]; then
-    echo "Unable to find unpacked Hubble home in ${work_dir}" >&2
-    exit 1
-fi
-
-echo "Starting Hubble candidate: ${hubble_home}"
-"${hubble_home}/bin/start-hubble.sh"
-
-for _ in $(seq 1 60); do
-    if curl -fsS "${hubble_url}/actuator/health" >/dev/null; then
-        break
+mkdir -p "${evidence_dir}/ui"
+runtime_work=$(mktemp -d "${TMPDIR:-/tmp}/hubble-694-runtime-XXXXXX")
+cleanup() {
+    hubble_home=$(find "${runtime_work}" -maxdepth 1 -type d \
+        -name 'apache-hugegraph-hubble-*' | head -n 1)
+    if [[ -n "${hubble_home}" && -x "${hubble_home}/bin/stop-hubble.sh" ]]; then
+        "${hubble_home}/bin/stop-hubble.sh" >/dev/null 2>&1 || true
     fi
-    sleep 1
-done
+    rm -rf "${runtime_work}"
+}
+trap cleanup EXIT
 
-curl -fsS "${hubble_url}/actuator/health" | grep -q '"UP"'
-curl -fsS "${hubble_url}/" | grep -q '<div id="root"></div>'
+"${python_bin}" "${script_dir}/run_live_hubble_smoke.py" "${tarball}" \
+    --server-url "${server_url}" \
+    --hubble-url "${hubble_url}" \
+    --graph "${graph_name}" \
+    --graphspace "${graphspace}" \
+    --loader-flow \
+    --analysis-boundary \
+    --work-dir "${runtime_work}" \
+    --keep-work-dir \
+    --leave-running \
+    --json-output "${evidence_dir}/live-hubble-smoke.json"
 
-for route in \
-    /graph-management \
-    /graph-management/1/metadata-configs \
-    /graph-management/1/data-import/import-manager \
-    /graph-management/1/data-analyze \
-    /graph-management/1/async-tasks
-do
-    curl -fsS "${hubble_url}${route}" | grep -q '<div id="root"></div>'
-done
+"${node_bin}" "${script_dir}/run_ui_full_acceptance.js" \
+    --hubble-url "${hubble_url}" \
+    --output-dir "${evidence_dir}/ui" \
+    --json-output "${evidence_dir}/ui-full-acceptance.json"
 
-curl -fsS "${server_url}/versions" >/dev/null
-
-connection_body=$(cat <<JSON
-{"name":"issue_694_local","graph":"${graph_name}","host":"${server_host}","port":${server_port},"username":"","password":"","protocol":"${server_protocol}"}
+cat > "${evidence_dir}/manifest.json" <<JSON
+{
+  "status": "passed",
+  "hubbleUrl": "${hubble_url}",
+  "serverUrl": "${server_url}",
+  "graphspace": "${graphspace}",
+  "graph": "${graph_name}",
+  "runtime": "${evidence_dir}/live-hubble-smoke.json",
+  "ui": "${evidence_dir}/ui-full-acceptance.json"
+}
 JSON
-)
 
-connection_response=$(curl -fsS \
-    -H 'Content-Type: application/json' \
-    -d "${connection_body}" \
-    "${hubble_url}/api/v1.2/graph-connections")
-if ! echo "${connection_response}" | grep -q '"status":200'; then
-    echo "Failed to create Hubble graph connection" >&2
-    echo "${connection_response}" >&2
-    exit 1
-fi
-
-conn_id=$(printf '%s' "${connection_response}" |
-          sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
-
-if [[ -z "${conn_id}" ]]; then
-    echo "Unable to resolve Hubble graph connection id" >&2
-    echo "${connection_response}" >&2
-    exit 1
-fi
-
-schema_response=$(curl -fsS \
-    "${hubble_url}/api/v1.2/graph-connections/${conn_id}/schema/graphview")
-if ! echo "${schema_response}" | grep -q '"status":200'; then
-    echo "Hubble schema graphview API failed" >&2
-    echo "${schema_response}" >&2
-    exit 1
-fi
-
-job_response=$(curl -fsS \
-    "${hubble_url}/api/v1.2/graph-connections/${conn_id}/job-manager?page_no=1&page_size=10")
-if ! echo "${job_response}" | grep -q '"status":200'; then
-    echo "Hubble job-manager API failed" >&2
-    echo "${job_response}" >&2
-    exit 1
-fi
-
-task_response=$(curl -fsS \
-    "${hubble_url}/api/v1.2/graph-connections/${conn_id}/async-tasks?page_no=1&page_size=10")
-if ! echo "${task_response}" | grep -q '"status":200'; then
-    echo "Hubble async-tasks API failed" >&2
-    echo "${task_response}" >&2
-    exit 1
-fi
-
-echo "Hubble issue #694 smoke passed with connection id ${conn_id}"
+echo "Hubble issue #694 smoke passed; evidence: ${evidence_dir}"

--- a/hugegraph-hubble/hubble-fe/package.json
+++ b/hugegraph-hubble/hubble-fe/package.json
@@ -76,6 +76,7 @@
     "@ecomfe/stylelint-config": "^1.1.2",
     "eslint": "^8.19.0",
     "eslint-plugin-react": "^7.30.1",
+    "playwright": "^1.61.1",
     "resize-observer-polyfill": "^1.5.1"
   }
 }

--- a/hugegraph-hubble/hubble-fe/yarn.lock
+++ b/hugegraph-hubble/hubble-fe/yarn.lock
@@ -6019,6 +6019,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmmirror.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -8723,6 +8728,20 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+playwright-core@1.61.1:
+  version "1.61.1"
+  resolved "https://registry.npmmirror.com/playwright-core/-/playwright-core-1.61.1.tgz#3c99841307efbbabc9d724c41a88c914705d15fc"
+  integrity sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==
+
+playwright@^1.61.1:
+  version "1.61.1"
+  resolved "https://registry.npmmirror.com/playwright/-/playwright-1.61.1.tgz#d8c0c06eb93c28981afc747bace453bdbd5018bc"
+  integrity sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==
+  dependencies:
+    playwright-core "1.61.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 polished@4:
   version "4.3.1"


### PR DESCRIPTION
## Summary
- add packaged Hubble startup and Server smoke helper for issue #694 runtime validation
- cover Loader import, Gremlin count comparison, and shortestPath graph-view comparison
- add Playwright browser route and runtime i18n switch smoke scripts
- aggregate UI runtime checks with JSON evidence output

## Validation
- python3 -m py_compile hugegraph-hubble/hubble-dist/assembly/travis/run_live_hubble_smoke.py
- node --check hugegraph-hubble/hubble-dist/assembly/travis/run_ui_browser_smoke.js
- node --check hugegraph-hubble/hubble-dist/assembly/travis/run_ui_full_acceptance.js
- node --check hugegraph-hubble/hubble-dist/assembly/travis/run_ui_i18n_switch_smoke.js
- bash -n hugegraph-hubble/hubble-dist/assembly/travis/verify-hubble-issue-694.sh
- git diff --check
- mvn -pl hugegraph-hubble editorconfig:check -ntp

## Stacking note
This PR is stacked on #12 so GitHub checks run against the Hubble backend compile fixes already required by the hubble2 baseline. After #12 lands, this branch should be rebased onto the latest hubble2 to shrink the displayed diff to the runtime smoke scripts.

Refs #694