### PR TITLE
fix(env): validate Hubble with local HStore

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -19,7 +19,7 @@ frontend dependencies without building or starting services.
   functional-test profile, not a memory or compatibility guarantee.
 - HStore starts with Server access control enabled. Connect Hubble to
   `http://127.0.0.1:8080` as `admin` with password `pa`, or set
-  `HUBBLE_SERVER_PASSWORD` before the first start to use a local alternative.
+  `HUGEGRAPH_ADMIN_PASSWORD` before the first start to use a local alternative.
   The password only initializes a new local data volume; stopping services
   preserves the original password. Use `Infrastructure Reset` to initialize
   fresh local data if that password is lost. This known credential is only for

--- a/.codex/infra/compose.low-memory.yml
+++ b/.codex/infra/compose.low-memory.yml
@@ -81,6 +81,7 @@ services:
         -Draft.maxBodySize=131072
 
   server:
+    image: ${HUGEGRAPH_SERVER_IMAGE:-hugegraph/server:latest}
     pull_policy: never
     mem_limit: 768m
     cpus: 4.0
@@ -89,7 +90,7 @@ services:
       - "--"
       - /opt/toolchain-low-memory/patch-server-config.sh
     environment:
-      PASSWORD: ${HUBBLE_SERVER_PASSWORD:-pa}
+      PASSWORD: ${HUGEGRAPH_ADMIN_PASSWORD:-pa}
       JAVA_OPTS: >-
         -Xms128m -Xmx192m
         -XX:ActiveProcessorCount=4
@@ -106,3 +107,29 @@ services:
         source: ${TOOLCHAIN_CODEX_DIR}/infra/patch-server-config.sh
         target: /opt/toolchain-low-memory/patch-server-config.sh
         read_only: true
+
+  hubble:
+    image: ${HUBBLE_IMAGE:-hugegraph/hubble:latest}
+    pull_policy: never
+    container_name: hg-hubble
+    hostname: hubble
+    restart: unless-stopped
+    networks: [hg-net]
+    depends_on:
+      server:
+        condition: service_healthy
+    mem_limit: 768m
+    cpus: 2.0
+    ports:
+      - "8088:8088"
+    volumes:
+      - type: bind
+        source: ${TOOLCHAIN_CODEX_DIR}/infra/hugegraph-hubble.properties
+        target: /hubble/conf/hugegraph-hubble.properties
+        read_only: true
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c ': </dev/tcp/hubble/8088'"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s

--- a/.codex/infra/hugegraph-hubble.properties
+++ b/.codex/infra/hugegraph-hubble.properties
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+hubble.host=0.0.0.0
+hubble.port=8088
+
+cluster=hg
+idc=docker
+
+pd.enabled=true
+server.direct_url=http://server:8080
+pd.peers=pd:8686
+pd.server=pd:8620
+
+operations.store.allowed_targets=[http://store:8520]

--- a/.codex/infra/patch-server-config.sh
+++ b/.codex/infra/patch-server-config.sh
@@ -23,6 +23,7 @@ unset CDPATH
 CONF_DIR=${HG_SERVER_CONF_DIR:-./conf}
 REST_CONF="${CONF_DIR}/rest-server.properties"
 GREMLIN_CONF="${CONF_DIR}/gremlin-server.yaml"
+GRAPH_CONF="${CONF_DIR}/graphs/hugegraph.properties"
 
 set_property() {
     local file=$1 key=$2 value=$3 escaped
@@ -50,11 +51,21 @@ set_yaml_scalar() {
 
 [[ -f "${REST_CONF}" ]] || { echo "ERROR: missing ${REST_CONF}" >&2; exit 1; }
 [[ -f "${GREMLIN_CONF}" ]] || { echo "ERROR: missing ${GREMLIN_CONF}" >&2; exit 1; }
+[[ -f "${GRAPH_CONF}" ]] || { echo "ERROR: missing ${GRAPH_CONF}" >&2; exit 1; }
 
 set_property "${REST_CONF}" batch.max_write_threads \
     "${HG_SERVER_BATCH_WRITE_THREADS:-2}"
 set_property "${REST_CONF}" restserver.min_free_memory \
-    "${HG_SERVER_MIN_FREE_MEMORY:-16}"
+    "${HG_SERVER_MIN_FREE_MEMORY:-0}"
+set_property "${REST_CONF}" usePD "${HG_SERVER_USE_PD:-true}"
+set_property "${REST_CONF}" pd.peers "${HG_SERVER_PD_PEERS:-pd:8686}"
+set_property "${REST_CONF}" restserver.url \
+    "${HG_SERVER_REST_URL:-http://server:8080}"
+set_property "${REST_CONF}" auth.token_secret \
+    "${HG_SERVER_AUTH_TOKEN_SECRET:-hugegraph-local-jwt-secret-change-me}"
+set_property "${GRAPH_CONF}" pd.peers "${HG_SERVER_PD_PEERS:-pd:8686}"
+set_property "${GRAPH_CONF}" auth.token_secret \
+    "${HG_SERVER_AUTH_TOKEN_SECRET:-hugegraph-local-jwt-secret-change-me}"
 set_yaml_scalar "${GREMLIN_CONF}" threadPoolWorker \
     "${HG_SERVER_GREMLIN_WORKERS:-2}"
 set_yaml_scalar "${GREMLIN_CONF}" gremlinPool \

--- a/.codex/scripts/infra.sh
+++ b/.codex/scripts/infra.sh
@@ -112,6 +112,7 @@ hstore_start() {
     assert_docker
     warn_dirty_server "${server_repo}"
     assert_port_available_for_compose 8080 hg-server
+    assert_port_available_for_compose 8088 hg-hubble
     assert_port_available_for_compose 8520 hg-store
     assert_port_available_for_compose 8620 hg-pd
     compose_files "${profile}" "${server_repo}"
@@ -130,7 +131,7 @@ infra_status() {
     echo
     docker stats --no-stream --format \
         'table {{.Name}}\t{{.MemUsage}}\t{{.CPUPerc}}' \
-        hg-pd hg-store hg-server 2>/dev/null || true
+        hg-pd hg-store hg-server hg-hubble 2>/dev/null || true
     echo
     lsof -nP -iTCP:8080 -sTCP:LISTEN 2>/dev/null || true
 }

--- a/.codex/tests/environment_test.sh
+++ b/.codex/tests/environment_test.sh
@@ -135,18 +135,30 @@ test_server_config_patch() {
     local conf="${TEST_TMP}/server-conf"
     local output
     mkdir -p "${conf}"
+    mkdir -p "${conf}/graphs"
     cat > "${conf}/rest-server.properties" <<'EOF'
 batch.max_write_threads=16
 EOF
     cat > "${conf}/gremlin-server.yaml" <<'EOF'
 other: 1
 EOF
+    cat > "${conf}/graphs/hugegraph.properties" <<'EOF'
+backend=hstore
+EOF
 
     output=$(HG_SERVER_CONF_DIR="${conf}" \
         "${CODEX_DIR}/infra/patch-server-config.sh" --patch-only 2>&1)
 
     grep -qx 'batch.max_write_threads=2' "${conf}/rest-server.properties"
-    grep -qx 'restserver.min_free_memory=16' "${conf}/rest-server.properties"
+    grep -qx 'restserver.min_free_memory=0' "${conf}/rest-server.properties"
+    grep -qx 'usePD=true' "${conf}/rest-server.properties"
+    grep -qx 'pd.peers=pd:8686' "${conf}/rest-server.properties"
+    grep -qx 'restserver.url=http://server:8080' "${conf}/rest-server.properties"
+    grep -qx 'auth.token_secret=hugegraph-local-jwt-secret-change-me' \
+        "${conf}/rest-server.properties"
+    grep -qx 'pd.peers=pd:8686' "${conf}/graphs/hugegraph.properties"
+    grep -qx 'auth.token_secret=hugegraph-local-jwt-secret-change-me' \
+        "${conf}/graphs/hugegraph.properties"
     grep -qx 'other: 1' "${conf}/gremlin-server.yaml"
     assert_contains "${output}" "WARN: property 'restserver.min_free_memory'"
     assert_contains "${output}" "WARN: optional YAML key 'threadPoolWorker'"
@@ -157,7 +169,10 @@ test_server_config_patch_requires_config_files() {
     local missing_rest="${TEST_TMP}/server-conf-missing-rest"
     local missing_yaml="${TEST_TMP}/server-conf-missing-yaml" output
     mkdir -p "${missing_rest}" "${missing_yaml}"
+    mkdir -p "${missing_rest}/graphs" "${missing_yaml}/graphs"
     printf 'batch.max_write_threads=16\n' > "${missing_yaml}/rest-server.properties"
+    printf 'backend=hstore\n' > "${missing_rest}/graphs/hugegraph.properties"
+    printf 'backend=hstore\n' > "${missing_yaml}/graphs/hugegraph.properties"
 
     if output=$(HG_SERVER_CONF_DIR="${missing_rest}" \
         "${CODEX_DIR}/infra/patch-server-config.sh" --patch-only 2>&1); then


### PR DESCRIPTION
## Summary

- add Hubble to the low-memory PD and HStore development environment
- support local Server and Hubble branch images with pull disabled
- align Server PD registration, reachable URL, memory guard, and JWT configuration
- document the shared admin-password override

## Verification

- environment contract suite: passed
- layered Compose config with local images and pull_policy never: passed
- independent review and re-review: no actionable findings

## Pending before ready

- clean-volume four-service Docker E2E is blocked by local Docker storage exhaustion; no image will be pushed