### PR TITLE
fix(hubble): use bearer token for authenticated clients

### DIFF
--- a/hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/controller/BaseController.java
+++ b/hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/controller/BaseController.java
@@ -196,7 +196,7 @@ public abstract class BaseController {
         HttpServletRequest request = getRequest();
         if (request.getAttribute("hugeClient") != null) {
             HugeClient client = (HugeClient) request.getAttribute("hugeClient");
-            client.setAuthContext("Basic " + this.getToken());
+            client.setAuthContext("Bearer " + this.getToken());
             return client;
         }
         HugeClient client = this.hugeClientPoolService.createTempTokenClient(this.getToken());

--- a/hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/util/HugeClientUtil.java
+++ b/hugegraph-hubble/hubble-be/src/main/java/org/apache/hugegraph/util/HugeClientUtil.java
@@ -112,6 +112,10 @@ public final class HugeClientUtil {
             throw e;
         }
 
+        if (StringUtils.isNotBlank(connection.getToken())) {
+            client.setAuthContext("Bearer " + connection.getToken().trim());
+        }
+
         return client;
     }
 

--- a/hugegraph-hubble/hubble-be/src/test/java/org/apache/hugegraph/unit/BaseControllerGremlinClientTest.java
+++ b/hugegraph-hubble/hubble-be/src/test/java/org/apache/hugegraph/unit/BaseControllerGremlinClientTest.java
@@ -81,6 +81,22 @@ public class BaseControllerGremlinClientTest {
         Assert.assertEquals("hugegraph", controller.graph);
     }
 
+    @Test
+    public void testReusedTemporaryClientUsesBearerToken() {
+        HugeClient tokenClient = Mockito.mock(HugeClient.class);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute(Constant.USERNAME_KEY, "admin");
+        request.getSession().setAttribute(Constant.TOKEN_KEY, "jwt-token");
+        request.setAttribute("hugeClient", tokenClient);
+        RequestContextHolder.setRequestAttributes(
+                new ServletRequestAttributes(request));
+
+        TestController controller = new TestController();
+
+        Assert.assertSame(tokenClient, controller.temporaryTokenClient());
+        Mockito.verify(tokenClient).setAuthContext("Bearer jwt-token");
+    }
+
     private MockHttpServletRequest requestWithAuth() {
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.getSession().setAttribute(Constant.USERNAME_KEY, "admin");
@@ -100,6 +116,10 @@ public class BaseControllerGremlinClientTest {
 
         HugeClient gremlinClient(String graphSpace, String graph) {
             return this.authGremlinClient(graphSpace, graph);
+        }
+
+        HugeClient temporaryTokenClient() {
+            return this.tempTokenClient();
         }
 
         @Override

--- a/hugegraph-hubble/hubble-be/src/test/java/org/apache/hugegraph/util/HugeClientUtilTest.java
+++ b/hugegraph-hubble/hubble-be/src/test/java/org/apache/hugegraph/util/HugeClientUtilTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hugegraph.util;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.hugegraph.api.gremlin.GremlinRequest;
+import org.apache.hugegraph.driver.HugeClient;
+import org.apache.hugegraph.entity.GraphConnection;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+
+public class HugeClientUtilTest {
+
+    @Test
+    public void testTokenClientSendsBearerToGremlin() throws Exception {
+        AtomicReference<String> authorization = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1",
+                                                                    0), 0);
+        server.createContext("/versions", exchange -> respond(exchange,
+                             "{\"versions\":{\"core\":\"1.8.0\"," +
+                             "\"gremlin\":\"3.7.3\",\"api\":\"0.71\"}}"));
+        server.createContext("/gremlin", exchange -> {
+            authorization.set(exchange.getRequestHeaders()
+                                      .getFirst("Authorization"));
+            respond(exchange, "{\"requestId\":\"1\"," +
+                     "\"status\":{\"message\":\"\",\"code\":200," +
+                     "\"attributes\":{}}," +
+                     "\"result\":{\"data\":[1],\"meta\":{}}}");
+        });
+        server.start();
+
+        GraphConnection connection = GraphConnection.builder()
+                                                    .graphSpace("DEFAULT")
+                                                    .graph("hugegraph")
+                                                    .host("127.0.0.1")
+                                                    .port(server.getAddress()
+                                                                .getPort())
+                                                    .timeout(5)
+                                                    .token("jwt-value")
+                                                    .build();
+        try (HugeClient client = HugeClientUtil.tryConnect(connection)) {
+            client.gremlin().execute(new GremlinRequest("g.V().count()"));
+            Assert.assertEquals("Bearer jwt-value", authorization.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static void respond(HttpExchange exchange, String response)
+                                throws IOException {
+        byte[] body = response.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, body.length);
+        try (OutputStream output = exchange.getResponseBody()) {
+            output.write(body);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- send Hubble JWT credentials with the standard Bearer scheme
- preserve Bearer authentication when reusing request-scoped clients
- verify the real HugeClient request header sent to the Gremlin endpoint

This PR intentionally excludes all .codex environment changes.

## Related PR

- Server and Compose counterpart: https://github.com/hugegraph/hugegraph/pull/165
- This PR provides the Hubble client side of the shared Bearer contract; hugegraph/hugegraph#165 provides embedded Gremlin Bearer verification and the PD Docker integration. They are scoped independently but should be validated and released together.

## Scope audit

- Closed PR #21 contains one commit and changes six .codex paths only.
- The combined PR #22 had one additional non-.codex file: hugegraph-hubble/README.md. Its seven lines only linked to the excluded .codex guide, so retaining them would create a broken link.
- The authentication patch in this PR has the same stable patch-id as the original authentication commit from #22.

## Verification

- JDK 11 Hubble unit suite: 396 tests passed
- Apache RAT: passed for hubble-be
- independent review and re-review: no actionable authentication findings
- local branch image built as local/hugegraph-hubble:hubble-pd

## Pending before ready

- clean-volume four-service Docker E2E requires local BuildKit cache cleanup; no image will be pushed